### PR TITLE
Allow specifying custom request URL to support local dynamo docker container

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*.cs]
+dotnet_style_require_accessibility_modifiers = always:warning

--- a/EfficientDynamoDb.sln
+++ b/EfficientDynamoDb.sln
@@ -1,15 +1,21 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks", "src\Benchmarks\Benchmarks.csproj", "{E1984343-896A-44C2-BF7C-C26805EE74C3}"
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31105.61
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Benchmarks", "src\Benchmarks\Benchmarks.csproj", "{E1984343-896A-44C2-BF7C-C26805EE74C3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EfficientDynamoDb", "src\EfficientDynamoDb\EfficientDynamoDb.csproj", "{381583B4-01A6-4E01-9514-D4F503705CD1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EfficientDynamoDb", "src\EfficientDynamoDb\EfficientDynamoDb.csproj", "{381583B4-01A6-4E01-9514-D4F503705CD1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1355AE02-EEBA-486C-9753-A005C8E52B88}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E1984343-896A-44C2-BF7C-C26805EE74C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -20,5 +26,11 @@ Global
 		{381583B4-01A6-4E01-9514-D4F503705CD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{381583B4-01A6-4E01-9514-D4F503705CD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{381583B4-01A6-4E01-9514-D4F503705CD1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BFD0314E-09ED-4364-959C-02F37A8506CC}
 	EndGlobalSection
 EndGlobal

--- a/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
+++ b/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
@@ -11,7 +11,7 @@ namespace EfficientDynamoDb.Configs
         
         public string Region { get; }
 
-        static RegionEndpoint Create(string region, string uriFormat)
+        private static RegionEndpoint Create(string region, string uriFormat)
         {
             return new RegionEndpoint(region, string.Format(uriFormat, ServiceName, region));
         }

--- a/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
+++ b/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
@@ -7,144 +7,154 @@ namespace EfficientDynamoDb.Configs
         
         internal const string ServiceName = "dynamodb";
 
-        internal string RequestUri { get; }
+        internal string RequestUri { get; private set; }
         
         public string Region { get; }
 
-        private static RegionEndpoint Create(string region, string uriFormat)
+        public static RegionEndpoint Create(string region)
         {
-            return new RegionEndpoint(region, string.Format(uriFormat, ServiceName, region));
+            return new RegionEndpoint(region, RegularEndpointFormat);
         }
-        
-        public RegionEndpoint(string region, string requestUri)
+
+        public static RegionEndpoint Create(string region, string requestUri)
+        {
+            return new RegionEndpoint(region, RegularEndpointFormat) { RequestUri = requestUri };
+        }
+
+        public static RegionEndpoint Create(RegionEndpoint region, string requestUri)
+        {
+            return new RegionEndpoint(region.Region, RegularEndpointFormat) { RequestUri = requestUri };
+        }
+
+        private RegionEndpoint(string region, string uriFormat = RegularEndpointFormat)
         {
             Region = region;
-            RequestUri = requestUri;
+            RequestUri = string.Format(uriFormat, ServiceName, region);
         }
 
         /// <summary>
         /// The US East (N. Virginia) endpoint.
         /// </summary>
-        public static RegionEndpoint USEast1 => Create("us-east-1", RegularEndpointFormat);
+        public static RegionEndpoint USEast1 => new RegionEndpoint("us-east-1");
         
         /// <summary>
         /// The US East (Ohio) endpoint.
         /// </summary>
-        public static RegionEndpoint USEast2 => Create("us-east-2", RegularEndpointFormat);
+        public static RegionEndpoint USEast2 => new RegionEndpoint("us-east-2");
         
         /// <summary>
         /// The US West (N. California) endpoint.
         /// </summary>
-        public static RegionEndpoint USWest1 => Create("us-west-1", RegularEndpointFormat);
+        public static RegionEndpoint USWest1 => new RegionEndpoint("us-west-1");
         
         /// <summary>
         /// The US West (Oregon) endpoint.
         /// </summary>
-        public static RegionEndpoint USWest2 => Create("us-west-2", RegularEndpointFormat);
+        public static RegionEndpoint USWest2 => new RegionEndpoint("us-west-2");
         
         /// <summary>
         /// The Africa (Cape Town) endpoint.
         /// </summary>
-        public static RegionEndpoint AFSouth1 => Create("af-south-1", RegularEndpointFormat);
+        public static RegionEndpoint AFSouth1 => new RegionEndpoint("af-south-1");
         
         /// <summary>
         /// The Asia Pacific (Hong Kong) endpoint.
         /// </summary>
-        public static RegionEndpoint APEast1 => Create("ap-east-1", RegularEndpointFormat);
+        public static RegionEndpoint APEast1 => new RegionEndpoint("ap-east-1");
         
         /// <summary>
         /// The Asia Pacific (Mumbai) endpoint.
         /// </summary>
-        public static RegionEndpoint APSouth1 => Create("ap-south-1", RegularEndpointFormat);
+        public static RegionEndpoint APSouth1 => new RegionEndpoint("ap-south-1");
         
         /// <summary>
         /// The Asia Pacific (Tokyo) endpoint.
         /// </summary>
-        public static RegionEndpoint APNorthEast1 => Create("ap-northeast-1", RegularEndpointFormat);
+        public static RegionEndpoint APNorthEast1 => new RegionEndpoint("ap-northeast-1");
         
         /// <summary>
         /// The Asia Pacific (Seoul) endpoint.
         /// </summary>
-        public static RegionEndpoint APNorthEast2 => Create("ap-northeast-2", RegularEndpointFormat);
+        public static RegionEndpoint APNorthEast2 => new RegionEndpoint("ap-northeast-2");
         
         /// <summary>
         /// The Asia Pacific (Osaka-Local) endpoint.
         /// </summary>
-        public static RegionEndpoint APNorthEast3 => Create("ap-northeast-3", RegularEndpointFormat);
+        public static RegionEndpoint APNorthEast3 => new RegionEndpoint("ap-northeast-3");
         
         /// <summary>
         /// The Asia Pacific (Singapore) endpoint.
         /// </summary>
-        public static RegionEndpoint APSouthEast1 => Create("ap-southeast-1", RegularEndpointFormat);
+        public static RegionEndpoint APSouthEast1 => new RegionEndpoint("ap-southeast-1");
         
         /// <summary>
         /// The Asia Pacific (Sydney) endpoint.
         /// </summary>
-        public static RegionEndpoint APSouthEast2 => Create("ap-southeast-2", RegularEndpointFormat);
+        public static RegionEndpoint APSouthEast2 => new RegionEndpoint("ap-southeast-2");
         
         /// <summary>
         /// The Canada (Central) endpoint.
         /// </summary>
-        public static RegionEndpoint CACentral1 => Create("ca-central-1", RegularEndpointFormat);
+        public static RegionEndpoint CACentral1 => new RegionEndpoint("ca-central-1");
         
         /// <summary>
         /// The China (Beijing) endpoint.
         /// </summary>
-        public static RegionEndpoint CNNorth1 => Create("cn-north-1", ChinaEndpointFormat);
+        public static RegionEndpoint CNNorth1 => new RegionEndpoint("cn-north-1", ChinaEndpointFormat);
         
         /// <summary>
         /// The China (Ningxia) endpoint.
         /// </summary>
-        public static RegionEndpoint CNNorthWest1 => Create("cn-northwest-1", ChinaEndpointFormat);
+        public static RegionEndpoint CNNorthWest1 => new RegionEndpoint("cn-northwest-1", ChinaEndpointFormat);
         
         /// <summary>
         /// The Europe (Frankfurt) endpoint.
         /// </summary>
-        public static RegionEndpoint EUCenteral1 => Create("eu-central-1", RegularEndpointFormat);
+        public static RegionEndpoint EUCenteral1 => new RegionEndpoint("eu-central-1");
         
         /// <summary>
         /// The Europe (Ireland) endpoint.
         /// </summary>
-        public static RegionEndpoint EUWest1 => Create("eu-west-1", RegularEndpointFormat);
+        public static RegionEndpoint EUWest1 => new RegionEndpoint("eu-west-1");
         
         /// <summary>
         /// The Europe (London) endpoint.
         /// </summary>
-        public static RegionEndpoint EUWest2 => Create("eu-west-2", RegularEndpointFormat);
+        public static RegionEndpoint EUWest2 => new RegionEndpoint("eu-west-2");
         
         /// <summary>
         /// The Europe (Paris) endpoint.
         /// </summary>
-        public static RegionEndpoint EUWest3 => Create("eu-west-3", RegularEndpointFormat);
+        public static RegionEndpoint EUWest3 => new RegionEndpoint("eu-west-3");
         
         /// <summary>
         /// The Europe (Milan) endpoint.
         /// </summary>
-        public static RegionEndpoint EUSouth1 => Create("eu-south-1", RegularEndpointFormat);
+        public static RegionEndpoint EUSouth1 => new RegionEndpoint("eu-south-1");
         
         /// <summary>
         /// The Europe (Stockholm) endpoint.
         /// </summary>
-        public static RegionEndpoint EUNorth1 => Create("eu-north-1", RegularEndpointFormat);
+        public static RegionEndpoint EUNorth1 => new RegionEndpoint("eu-north-1");
         
         /// <summary>
         /// The Middle East (Bahrain) endpoint.
         /// </summary>
-        public static RegionEndpoint MESouth1 => Create("me-south-1", RegularEndpointFormat);
+        public static RegionEndpoint MESouth1 => new RegionEndpoint("me-south-1");
         
         /// <summary>
         /// The South America (São Paulo) endpoint.
         /// </summary>
-        public static RegionEndpoint SAEast1 => Create("sa-east-1", RegularEndpointFormat);
+        public static RegionEndpoint SAEast1 => new RegionEndpoint("sa-east-1");
         
         /// <summary>
         /// The AWS GovCloud (US-East) endpoint.
         /// </summary>
-        public static RegionEndpoint USGovEast1 => Create("us-gov-east-1", RegularEndpointFormat);
+        public static RegionEndpoint USGovEast1 => new RegionEndpoint("us-gov-east-1");
         
         /// <summary>
         /// The AWS GovCloud (US) endpoint.
         /// </summary>
-        public static RegionEndpoint USGovWest1 => Create("us-gov-west-1", RegularEndpointFormat);
+        public static RegionEndpoint USGovWest1 => new RegionEndpoint("us-gov-west-1");
     }
 }

--- a/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
+++ b/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
@@ -10,136 +10,141 @@ namespace EfficientDynamoDb.Configs
         internal string RequestUri { get; }
         
         public string Region { get; }
+
+        static RegionEndpoint Create(string region, string uriFormat)
+        {
+            return new RegionEndpoint(region, string.Format(uriFormat, ServiceName, region));
+        }
         
-        private RegionEndpoint(string region, string uriFormat)
+        public RegionEndpoint(string region, string requestUri)
         {
             Region = region;
-            RequestUri = string.Format(uriFormat, ServiceName, region);
+            RequestUri = requestUri;
         }
 
         /// <summary>
         /// The US East (N. Virginia) endpoint.
         /// </summary>
-        public static RegionEndpoint USEast1 => new RegionEndpoint("us-east-1", RegularEndpointFormat);
+        public static RegionEndpoint USEast1 => Create("us-east-1", RegularEndpointFormat);
         
         /// <summary>
         /// The US East (Ohio) endpoint.
         /// </summary>
-        public static RegionEndpoint USEast2 => new RegionEndpoint("us-east-2", RegularEndpointFormat);
+        public static RegionEndpoint USEast2 => Create("us-east-2", RegularEndpointFormat);
         
         /// <summary>
         /// The US West (N. California) endpoint.
         /// </summary>
-        public static RegionEndpoint USWest1 => new RegionEndpoint("us-west-1", RegularEndpointFormat);
+        public static RegionEndpoint USWest1 => Create("us-west-1", RegularEndpointFormat);
         
         /// <summary>
         /// The US West (Oregon) endpoint.
         /// </summary>
-        public static RegionEndpoint USWest2 => new RegionEndpoint("us-west-2", RegularEndpointFormat);
+        public static RegionEndpoint USWest2 => Create("us-west-2", RegularEndpointFormat);
         
         /// <summary>
         /// The Africa (Cape Town) endpoint.
         /// </summary>
-        public static RegionEndpoint AFSouth1 => new RegionEndpoint("af-south-1", RegularEndpointFormat);
+        public static RegionEndpoint AFSouth1 => Create("af-south-1", RegularEndpointFormat);
         
         /// <summary>
         /// The Asia Pacific (Hong Kong) endpoint.
         /// </summary>
-        public static RegionEndpoint APEast1 => new RegionEndpoint("ap-east-1", RegularEndpointFormat);
+        public static RegionEndpoint APEast1 => Create("ap-east-1", RegularEndpointFormat);
         
         /// <summary>
         /// The Asia Pacific (Mumbai) endpoint.
         /// </summary>
-        public static RegionEndpoint APSouth1 => new RegionEndpoint("ap-south-1", RegularEndpointFormat);
+        public static RegionEndpoint APSouth1 => Create("ap-south-1", RegularEndpointFormat);
         
         /// <summary>
         /// The Asia Pacific (Tokyo) endpoint.
         /// </summary>
-        public static RegionEndpoint APNorthEast1 => new RegionEndpoint("ap-northeast-1", RegularEndpointFormat);
+        public static RegionEndpoint APNorthEast1 => Create("ap-northeast-1", RegularEndpointFormat);
         
         /// <summary>
         /// The Asia Pacific (Seoul) endpoint.
         /// </summary>
-        public static RegionEndpoint APNorthEast2 => new RegionEndpoint("ap-northeast-2", RegularEndpointFormat);
+        public static RegionEndpoint APNorthEast2 => Create("ap-northeast-2", RegularEndpointFormat);
         
         /// <summary>
         /// The Asia Pacific (Osaka-Local) endpoint.
         /// </summary>
-        public static RegionEndpoint APNorthEast3 => new RegionEndpoint("ap-northeast-3", RegularEndpointFormat);
+        public static RegionEndpoint APNorthEast3 => Create("ap-northeast-3", RegularEndpointFormat);
         
         /// <summary>
         /// The Asia Pacific (Singapore) endpoint.
         /// </summary>
-        public static RegionEndpoint APSouthEast1 => new RegionEndpoint("ap-southeast-1", RegularEndpointFormat);
+        public static RegionEndpoint APSouthEast1 => Create("ap-southeast-1", RegularEndpointFormat);
         
         /// <summary>
         /// The Asia Pacific (Sydney) endpoint.
         /// </summary>
-        public static RegionEndpoint APSouthEast2 => new RegionEndpoint("ap-southeast-2", RegularEndpointFormat);
+        public static RegionEndpoint APSouthEast2 => Create("ap-southeast-2", RegularEndpointFormat);
         
         /// <summary>
         /// The Canada (Central) endpoint.
         /// </summary>
-        public static RegionEndpoint CACentral1 => new RegionEndpoint("ca-central-1", RegularEndpointFormat);
+        public static RegionEndpoint CACentral1 => Create("ca-central-1", RegularEndpointFormat);
         
         /// <summary>
         /// The China (Beijing) endpoint.
         /// </summary>
-        public static RegionEndpoint CNNorth1 => new RegionEndpoint("cn-north-1", ChinaEndpointFormat);
+        public static RegionEndpoint CNNorth1 => Create("cn-north-1", ChinaEndpointFormat);
         
         /// <summary>
         /// The China (Ningxia) endpoint.
         /// </summary>
-        public static RegionEndpoint CNNorthWest1 => new RegionEndpoint("cn-northwest-1", ChinaEndpointFormat);
+        public static RegionEndpoint CNNorthWest1 => Create("cn-northwest-1", ChinaEndpointFormat);
         
         /// <summary>
         /// The Europe (Frankfurt) endpoint.
         /// </summary>
-        public static RegionEndpoint EUCenteral1 => new RegionEndpoint("eu-central-1", RegularEndpointFormat);
+        public static RegionEndpoint EUCenteral1 => Create("eu-central-1", RegularEndpointFormat);
         
         /// <summary>
         /// The Europe (Ireland) endpoint.
         /// </summary>
-        public static RegionEndpoint EUWest1 => new RegionEndpoint("eu-west-1", RegularEndpointFormat);
+        public static RegionEndpoint EUWest1 => Create("eu-west-1", RegularEndpointFormat);
         
         /// <summary>
         /// The Europe (London) endpoint.
         /// </summary>
-        public static RegionEndpoint EUWest2 => new RegionEndpoint("eu-west-2", RegularEndpointFormat);
+        public static RegionEndpoint EUWest2 => Create("eu-west-2", RegularEndpointFormat);
         
         /// <summary>
         /// The Europe (Paris) endpoint.
         /// </summary>
-        public static RegionEndpoint EUWest3 => new RegionEndpoint("eu-west-3", RegularEndpointFormat);
+        public static RegionEndpoint EUWest3 => Create("eu-west-3", RegularEndpointFormat);
         
         /// <summary>
         /// The Europe (Milan) endpoint.
         /// </summary>
-        public static RegionEndpoint EUSouth1 => new RegionEndpoint("eu-south-1", RegularEndpointFormat);
+        public static RegionEndpoint EUSouth1 => Create("eu-south-1", RegularEndpointFormat);
         
         /// <summary>
         /// The Europe (Stockholm) endpoint.
         /// </summary>
-        public static RegionEndpoint EUNorth1 => new RegionEndpoint("eu-north-1", RegularEndpointFormat);
+        public static RegionEndpoint EUNorth1 => Create("eu-north-1", RegularEndpointFormat);
         
         /// <summary>
         /// The Middle East (Bahrain) endpoint.
         /// </summary>
-        public static RegionEndpoint MESouth1 => new RegionEndpoint("me-south-1", RegularEndpointFormat);
+        public static RegionEndpoint MESouth1 => Create("me-south-1", RegularEndpointFormat);
         
         /// <summary>
         /// The South America (São Paulo) endpoint.
         /// </summary>
-        public static RegionEndpoint SAEast1 => new RegionEndpoint("sa-east-1", RegularEndpointFormat);
+        public static RegionEndpoint SAEast1 => Create("sa-east-1", RegularEndpointFormat);
         
         /// <summary>
         /// The AWS GovCloud (US-East) endpoint.
         /// </summary>
-        public static RegionEndpoint USGovEast1 => new RegionEndpoint("us-gov-east-1", RegularEndpointFormat);
+        public static RegionEndpoint USGovEast1 => Create("us-gov-east-1", RegularEndpointFormat);
         
         /// <summary>
         /// The AWS GovCloud (US) endpoint.
         /// </summary>
-        public static RegionEndpoint USGovWest1 => new RegionEndpoint("us-gov-west-1", RegularEndpointFormat);
+        public static RegionEndpoint USGovWest1 => Create("us-gov-west-1", RegularEndpointFormat);
     }
 }

--- a/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
+++ b/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
@@ -13,7 +13,12 @@ namespace EfficientDynamoDb.Configs
 
         public static RegionEndpoint Create(string region)
         {
-            return new RegionEndpoint(region, RegularEndpointFormat);
+            var format =
+                region.StartsWith("cn-", System.StringComparison.OrdinalIgnoreCase)
+                ? ChinaEndpointFormat
+                : RegularEndpointFormat;
+
+            return new RegionEndpoint(region, format);
         }
 
         public static RegionEndpoint Create(string region, string requestUri)


### PR DESCRIPTION
I'm starting to experiment with your library and the first issue I ran into is that I was unable to configure the endpoint URL to point at a local dynamo instance that I'm running in a docker container. The RegionEndpoint only allowed using one of the pre-existing regions, but there was no way to specify a custom URL (like http://localhost:8000). This PR exposes a public ctor on RegionEndpoint to allow this. This is a non-breaking change.

I don't know how often Amazon adds new regions, but this should also allow people to target new regions without having to update the library.