### PR TITLE
Override table name

### DIFF
--- a/src/EfficientDynamoDb/Batch.cs
+++ b/src/EfficientDynamoDb/Batch.cs
@@ -5,7 +5,7 @@ namespace EfficientDynamoDb
 {
     public static class Batch
     {
-        public static IBatchWriteBuilder PutItem<TEntity>(TEntity entity) where TEntity : class => new BatchPutItemBuilder(typeof(TEntity), entity);
+        public static IBatchPutItemBuilder PutItem<TEntity>(TEntity entity) where TEntity : class => new BatchPutItemBuilder(typeof(TEntity), entity);
         
         public static IBatchDeleteItemBuilder DeleteItem<TEntity>() where TEntity : class => new BatchDeleteItemBuilder(typeof(TEntity));
 

--- a/src/EfficientDynamoDb/Extensions/HighLevelExtensions.cs
+++ b/src/EfficientDynamoDb/Extensions/HighLevelExtensions.cs
@@ -1,0 +1,13 @@
+using EfficientDynamoDb.Operations.Query;
+using EfficientDynamoDb.Operations.Shared;
+
+namespace EfficientDynamoDb.Extensions
+{
+    public static class HighLevelExtensions
+    {
+        public static TBuilder WithTableName<TBuilder>(this TBuilder builder, string tableName) where TBuilder : ITableBuilder<TBuilder>
+        {
+            return builder.Create(new TableNameNode(tableName, builder.Node));
+        }
+    }
+}

--- a/src/EfficientDynamoDb/Extensions/HighLevelExtensions.cs
+++ b/src/EfficientDynamoDb/Extensions/HighLevelExtensions.cs
@@ -13,10 +13,8 @@ namespace EfficientDynamoDb.Extensions
         /// Overrides the table name defined in <see cref="DynamoDbTableAttribute"/>.
         /// </summary>
         /// <param name="tableName">The table name to use instead of <see cref="DynamoDbTableAttribute"/>.</param>
-        public static TBuilder WithTableName<TBuilder>(this TBuilder builder, string tableName) where TBuilder : ITableBuilder<TBuilder>
-        {
-            return builder.Create(new TableNameNode(tableName, builder.Node));
-        }
+        public static TBuilder WithTableName<TBuilder>(this TBuilder builder, string tableName) where TBuilder : ITableBuilder<TBuilder> =>
+            builder.Create(new TableNameNode(tableName, builder.Node));
 
         /// <summary>
         /// Overrides the table name defined in <see cref="DynamoDbTableAttribute"/>.

--- a/src/EfficientDynamoDb/Extensions/HighLevelExtensions.cs
+++ b/src/EfficientDynamoDb/Extensions/HighLevelExtensions.cs
@@ -1,13 +1,51 @@
+using System.IO;
+using EfficientDynamoDb.Attributes;
+using EfficientDynamoDb.Operations.BatchGetItem;
+using EfficientDynamoDb.Operations.BatchWriteItem;
 using EfficientDynamoDb.Operations.Query;
 using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Extensions
 {
-    public static class HighLevelExtensions
+    public static class TableNameExtensions
     {
+        /// <summary>
+        /// Overrides the table name defined in <see cref="DynamoDbTableAttribute"/>.
+        /// </summary>
+        /// <param name="tableName">The table name to use instead of <see cref="DynamoDbTableAttribute"/>.</param>
         public static TBuilder WithTableName<TBuilder>(this TBuilder builder, string tableName) where TBuilder : ITableBuilder<TBuilder>
         {
             return builder.Create(new TableNameNode(tableName, builder.Node));
+        }
+        
+        /// <summary>
+        /// Overrides the table name defined in <see cref="DynamoDbTableAttribute"/>.
+        /// </summary>
+        /// <param name="tableName">The table name to use instead of <see cref="DynamoDbTableAttribute"/>.</param>
+        public static IBatchDeleteItemBuilder WithTableName(this IBatchDeleteItemBuilder builder, string tableName)
+        {
+            builder.TableName = tableName;
+            return builder;
+        }
+        
+        /// <summary>
+        /// Overrides the table name defined in <see cref="DynamoDbTableAttribute"/>.
+        /// </summary>
+        /// <param name="tableName">The table name to use instead of <see cref="DynamoDbTableAttribute"/>.</param>
+        public static IBatchPutItemBuilder WithTableName(this IBatchPutItemBuilder builder, string tableName)
+        {
+            builder.TableName = tableName;
+            return builder;
+        }
+        
+        /// <summary>
+        /// Overrides the table name defined in <see cref="DynamoDbTableAttribute"/>.
+        /// </summary>
+        /// <param name="tableName">The table name to use instead of <see cref="DynamoDbTableAttribute"/>.</param>
+        public static IBatchGetItemBuilder WithTableName(this IBatchGetItemBuilder builder, string tableName)
+        {
+            builder.TableName = tableName;
+            return builder;
         }
     }
 }

--- a/src/EfficientDynamoDb/Extensions/HighLevelExtensions.cs
+++ b/src/EfficientDynamoDb/Extensions/HighLevelExtensions.cs
@@ -17,35 +17,23 @@ namespace EfficientDynamoDb.Extensions
         {
             return builder.Create(new TableNameNode(tableName, builder.Node));
         }
-        
+
         /// <summary>
         /// Overrides the table name defined in <see cref="DynamoDbTableAttribute"/>.
         /// </summary>
         /// <param name="tableName">The table name to use instead of <see cref="DynamoDbTableAttribute"/>.</param>
-        public static IBatchDeleteItemBuilder WithTableName(this IBatchDeleteItemBuilder builder, string tableName)
-        {
-            builder.TableName = tableName;
-            return builder;
-        }
-        
+        public static IBatchDeleteItemBuilder WithTableName(this IBatchDeleteItemBuilder builder, string tableName) => builder.WithTableName(tableName);
+
         /// <summary>
         /// Overrides the table name defined in <see cref="DynamoDbTableAttribute"/>.
         /// </summary>
         /// <param name="tableName">The table name to use instead of <see cref="DynamoDbTableAttribute"/>.</param>
-        public static IBatchPutItemBuilder WithTableName(this IBatchPutItemBuilder builder, string tableName)
-        {
-            builder.TableName = tableName;
-            return builder;
-        }
-        
+        public static IBatchPutItemBuilder WithTableName(this IBatchPutItemBuilder builder, string tableName) => builder.WithTableName(tableName);
+
         /// <summary>
         /// Overrides the table name defined in <see cref="DynamoDbTableAttribute"/>.
         /// </summary>
         /// <param name="tableName">The table name to use instead of <see cref="DynamoDbTableAttribute"/>.</param>
-        public static IBatchGetItemBuilder WithTableName(this IBatchGetItemBuilder builder, string tableName)
-        {
-            builder.TableName = tableName;
-            return builder;
-        }
+        public static IBatchGetItemBuilder WithTableName(this IBatchGetItemBuilder builder, string tableName) => builder.WithTableName(tableName);
     }
 }

--- a/src/EfficientDynamoDb/FluentCondition/UpdateExpression.cs
+++ b/src/EfficientDynamoDb/FluentCondition/UpdateExpression.cs
@@ -7,6 +7,7 @@ using EfficientDynamoDb.FluentCondition.Operators.Update.AssignConcat;
 using EfficientDynamoDb.FluentCondition.Operators.Update.AssignMath;
 using EfficientDynamoDb.Internal.Core;
 using EfficientDynamoDb.Operations.Query;
+using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.FluentCondition
 {
@@ -40,7 +41,8 @@ namespace EfficientDynamoDb.FluentCondition
     // Update.On(x => x.A).AssignConcat(x => x.B, x => x.A)
     // Update.On(x => x.A).AssignConcat(x => x.B, x => x.C)
 
-    public interface IUpdateItemBuilder<out TUpdateRequestBuilder>
+    public interface IUpdateItemBuilder<out TUpdateRequestBuilder> : ITableBuilder<TUpdateRequestBuilder> 
+        where TUpdateRequestBuilder : ITableBuilder<TUpdateRequestBuilder>
     {
         internal TUpdateRequestBuilder Create(UpdateBase update, BuilderNodeType nodeType);
     }

--- a/src/EfficientDynamoDb/Internal/Extensions/Utf8JsonWriterExtensions.UpdateItem.cs
+++ b/src/EfficientDynamoDb/Internal/Extensions/Utf8JsonWriterExtensions.UpdateItem.cs
@@ -9,11 +9,11 @@ namespace EfficientDynamoDb.Internal.Extensions
 {
     internal static partial class Utf8JsonWriterExtensions
     {
-        public static void WriteUpdateItem(this in DdbWriter ddbWriter, DynamoDbContextMetadata metadata, ref NoAllocStringBuilder builder, DdbExpressionVisitor visitor, DdbClassInfo classInfo, BuilderNode? node)
+        public static void WriteUpdateItem(this in DdbWriter ddbWriter, DynamoDbContextConfig config, ref NoAllocStringBuilder builder,
+            DdbExpressionVisitor visitor, DdbClassInfo classInfo, BuilderNode? node, ref int writeState)
         {
             var currentNode = node;
 
-            var writeState = 0;
             var hasAdd = false;
             var hasSet = false;
             var hasRemove = false;
@@ -50,6 +50,9 @@ namespace EfficientDynamoDb.Internal.Extensions
                         updateCondition ??= ((ConditionNode) currentNode).Value;
                         break;
                     }
+                    case BuilderNodeType.TableName:
+                        ((TableNameNode) currentNode).WriteTableName(in ddbWriter, ref writeState, config.TableNamePrefix);
+                        break;
                     default:
                     {
                         currentNode.WriteValue(in ddbWriter, ref writeState);
@@ -61,7 +64,7 @@ namespace EfficientDynamoDb.Internal.Extensions
             }
             
             if(firstUpdateNode != null)
-                WriteUpdates(in ddbWriter, metadata, ref builder, visitor, firstUpdateNode, lastUpdateNode!, hasAdd, hasSet, hasRemove, hasDelete, updateCondition);
+                WriteUpdates(in ddbWriter, config.Metadata, ref builder, visitor, firstUpdateNode, lastUpdateNode!, hasAdd, hasSet, hasRemove, hasDelete, updateCondition);
             
             builder.Clear();
             visitor.Clear();

--- a/src/EfficientDynamoDb/Internal/Operations/BatchWriteItem/BatchWriteItemHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/BatchWriteItem/BatchWriteItemHighLevelHttpContent.cs
@@ -75,15 +75,16 @@ namespace EfficientDynamoDb.Internal.Operations.BatchWriteItem
             for (var i = 0; i < operationsCount; i++)
             {
                 var (classInfo, builder) = sortedBuilders[i];
-                if (currentTable != classInfo.TableName)
+                var tableName = builder.TableName ?? classInfo.TableName;
+                if (currentTable != tableName)
                 {
                     if (i != 0)
                         writer.WriteEndArray();
 
-                    WriteTableNameAsKey(writer, _tableNamePrefix, classInfo.TableName!);
+                    WriteTableNameAsKey(writer, _tableNamePrefix, tableName!);
                     writer.WriteStartArray();
 
-                    currentTable = classInfo.TableName;
+                    currentTable = tableName;
                 }
 
                 switch (builder.NodeType)
@@ -126,8 +127,9 @@ namespace EfficientDynamoDb.Internal.Operations.BatchWriteItem
         private sealed class BatchWriteNodeComparer : IComparer<(DdbClassInfo ClassInfo, IBatchWriteBuilder Builder)>
         {
             public static readonly BatchWriteNodeComparer Instance = new BatchWriteNodeComparer();
-            
-            public int Compare((DdbClassInfo ClassInfo, IBatchWriteBuilder Builder) x, (DdbClassInfo ClassInfo, IBatchWriteBuilder Builder) y) => string.Compare(x.ClassInfo.TableName, y.ClassInfo.TableName, StringComparison.Ordinal);
+
+            public int Compare((DdbClassInfo ClassInfo, IBatchWriteBuilder Builder) x, (DdbClassInfo ClassInfo, IBatchWriteBuilder Builder) y) =>
+                string.Compare(x.Builder.TableName ?? x.ClassInfo.TableName, y.Builder.TableName ?? y.ClassInfo.TableName, StringComparison.Ordinal);
         }
     }
 }

--- a/src/EfficientDynamoDb/Internal/Operations/DeleteItem/DeleteItemHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/DeleteItem/DeleteItemHighLevelHttpContent.cs
@@ -25,8 +25,6 @@ namespace EfficientDynamoDb.Internal.Operations.DeleteItem
             var writer = ddbWriter.JsonWriter;
             writer.WriteStartObject();
 
-            writer.WriteTableName(_context.Config.TableNamePrefix, _classInfo.TableName!);
-
             var writeState = 0;
             
             foreach (var node in _node)
@@ -44,11 +42,17 @@ namespace EfficientDynamoDb.Internal.Operations.DeleteItem
 
                         writeState = writeState.SetBit(NodeBits.Condition);
                         break;
+                    case BuilderNodeType.TableName:
+                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                        break;
                     default:
                         node.WriteValue(in ddbWriter, ref writeState);
                         break;
                 }
             }
+            
+            if(!writeState.IsBitSet(NodeBits.TableName))
+                writer.WriteTableName(_context.Config.TableNamePrefix, _classInfo.TableName!);
             
             writer.WriteEndObject();
             

--- a/src/EfficientDynamoDb/Internal/Operations/GetItem/GetItemHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/GetItem/GetItemHighLevelHttpContent.cs
@@ -29,8 +29,6 @@ namespace EfficientDynamoDb.Internal.Operations.GetItem
             var writeState = 0;
             var projectionWritten = false;
 
-            writer.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, _classInfo.TableName!);
-            
             foreach (var node in _node)
             {
                 switch (node.Type)
@@ -62,11 +60,17 @@ namespace EfficientDynamoDb.Internal.Operations.GetItem
                         }
 
                         break;
+                    case BuilderNodeType.TableName:
+                        ((TableNameNode) node).WriteTableName(in writer, ref writeState, _context.Config.TableNamePrefix);
+                        break;
                     default:
                         node.WriteValue(in writer, ref writeState);
                         break;
                 }
             }
+            
+            if(!writeState.IsBitSet(NodeBits.TableName))
+                writer.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, _classInfo.TableName!);
             
             writer.JsonWriter.WriteEndObject();
 

--- a/src/EfficientDynamoDb/Internal/Operations/Query/QueryHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/Query/QueryHighLevelHttpContent.cs
@@ -29,8 +29,6 @@ namespace EfficientDynamoDb.Internal.Operations.Query
             var writer = ddbWriter.JsonWriter;
             writer.WriteStartObject();
 
-            writer.WriteTableName(_context.Config.TableNamePrefix, _tableName);
-
             BuilderNode? currentNode = _node;
             var wereExpressionsWritten = false;
             var writeState = 0;
@@ -50,6 +48,9 @@ namespace EfficientDynamoDb.Internal.Operations.Query
                         wereExpressionsWritten = true;
                         break;
                     }
+                    case BuilderNodeType.TableName:
+                        ((TableNameNode)currentNode).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                        break;
                     default:
                     {
                         currentNode.WriteValue(in ddbWriter, ref writeState);
@@ -59,6 +60,9 @@ namespace EfficientDynamoDb.Internal.Operations.Query
 
                 currentNode = currentNode.Next;
             }
+
+            if (!writeState.IsBitSet(NodeBits.TableName))
+                writer.WriteTableName(_context.Config.TableNamePrefix, _tableName);
 
             writer.WriteEndObject();
 

--- a/src/EfficientDynamoDb/Internal/Operations/Scan/ScanHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/Scan/ScanHighLevelHttpContent.cs
@@ -27,11 +27,8 @@ namespace EfficientDynamoDb.Internal.Operations.Scan
             var writer = ddbWriter.JsonWriter;
             writer.WriteStartObject();
 
-            writer.WriteTableName(_context.Config.TableNamePrefix, _tableName);
-
             var writeState = 0;
-          
-
+            
             if (_node != null)
             {
                 FilterBase? filterExpression = null;
@@ -47,6 +44,9 @@ namespace EfficientDynamoDb.Internal.Operations.Scan
                         case BuilderNodeType.ProjectedAttributes:
                             projectedAttributesStart ??= node;
                             break;
+                        case BuilderNodeType.TableName:
+                            ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                            break;
                         default:
                             node.WriteValue(in ddbWriter, ref writeState);
                             break;
@@ -56,6 +56,9 @@ namespace EfficientDynamoDb.Internal.Operations.Scan
                 if(filterExpression != null || projectedAttributesStart != null)
                     WriteExpressions(in ddbWriter, filterExpression, projectedAttributesStart);
             }
+            
+            if(!writeState.IsBitSet(NodeBits.TableName))
+                writer.WriteTableName(_context.Config.TableNamePrefix, _tableName);
 
             writer.WriteEndObject();
 

--- a/src/EfficientDynamoDb/Internal/Operations/TransactGetItems/TransactGetItemsHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/TransactGetItems/TransactGetItemsHighLevelHttpContent.cs
@@ -75,9 +75,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactGetItems
 
                     writer.WritePropertyName("Get");
                     writer.WriteStartObject();
-
-                    writer.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
-
+                    
                     var getWriteState = 0;
                     var projectionWritten = false;
 
@@ -102,8 +100,14 @@ namespace EfficientDynamoDb.Internal.Operations.TransactGetItems
                                 visitor.Clear();
                                 projectionWritten = true;
                                 break;
+                            case BuilderNodeType.TableName:
+                                ((TableNameNode) getNode).WriteTableName(in ddbWriter, ref getWriteState, _context.Config.TableNamePrefix);
+                                break;
                         }
                     }
+                    
+                    if(!getWriteState.IsBitSet(NodeBits.TableName))
+                        writer.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
 
                     writer.WriteEndObject();
 

--- a/src/EfficientDynamoDb/Internal/Operations/TransactWriteItems/TransactWriteItemsHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/TransactWriteItems/TransactWriteItemsHighLevelHttpContent.cs
@@ -105,10 +105,13 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
             ddbWriter.JsonWriter.WriteStartObject();
             
             var classInfo = _context.Config.Metadata.GetOrAddClassInfo(item.GetEntityType());
-            ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
+            var writeState = 0;
             
             visitor ??= new DdbExpressionVisitor(_context.Config.Metadata);
-            ddbWriter.WriteUpdateItem(_context.Config.Metadata, ref builder, visitor, classInfo, item.GetNode());
+            ddbWriter.WriteUpdateItem(_context.Config, ref builder, visitor, classInfo, item.GetNode(), ref writeState);
+
+            if (!writeState.IsBitSet(NodeBits.TableName))
+                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
 
             ddbWriter.JsonWriter.WriteEndObject();
             
@@ -124,7 +127,6 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
             ddbWriter.JsonWriter.WriteStartObject();
             
             var classInfo = _context.Config.Metadata.GetOrAddClassInfo(item.GetEntityType());
-            ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
             
             var writeState = 0;
             foreach (var node in item.GetNode())
@@ -143,11 +145,17 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
 
                         writeState = writeState.SetBit(NodeBits.Condition);
                         break;
+                    case BuilderNodeType.TableName:
+                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                        break;
                     default:
                         node.WriteValue(in ddbWriter, ref writeState);
                         break;
                 }
             }
+            
+            if(!writeState.IsBitSet(NodeBits.TableName))
+                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
 
             ddbWriter.JsonWriter.WriteEndObject();
             
@@ -161,9 +169,6 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
             ddbWriter.JsonWriter.WritePropertyName("Put");
             
             ddbWriter.JsonWriter.WriteStartObject();
-
-            var classInfo = _context.Config.Metadata.GetOrAddClassInfo(item.GetEntityType());
-            ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
             
             var writeState = 0;
             foreach (var node in item.GetNode())
@@ -190,12 +195,21 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
 
                         writeState = writeState.SetBit(NodeBits.Condition);
                         break;
+                    case BuilderNodeType.TableName:
+                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                        break;
                     default:
                         node.WriteValue(in ddbWriter, ref writeState);
                         break;
                 }
             }
 
+            if (!writeState.IsBitSet(NodeBits.TableName))
+            {
+                var classInfo = _context.Config.Metadata.GetOrAddClassInfo(item.GetEntityType());
+                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
+            }
+            
             ddbWriter.JsonWriter.WriteEndObject();
             
             ddbWriter.JsonWriter.WriteEndObject();
@@ -210,7 +224,6 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
             ddbWriter.JsonWriter.WriteStartObject();
 
             var classInfo = _context.Config.Metadata.GetOrAddClassInfo(item.GetEntityType());
-            ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
 
             var writeState = 0;
             foreach (var node in item.GetNode())
@@ -229,11 +242,17 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
 
                         writeState = writeState.SetBit(NodeBits.Condition);
                         break;
+                    case BuilderNodeType.TableName:
+                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                        break;
                     default:
                         node.WriteValue(in ddbWriter, ref writeState);
                         break;
                 }
             }
+            
+            if(!writeState.IsBitSet(NodeBits.TableName))
+                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
             
             ddbWriter.JsonWriter.WriteEndObject();
             

--- a/src/EfficientDynamoDb/Operations/BatchGetItem/BatchGetItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchGetItem/BatchGetItemBuilder.cs
@@ -7,12 +7,14 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
     internal sealed class BatchGetItemBuilder<TEntity> : IBatchGetItemBuilder where TEntity : class
     {
         private readonly PrimaryKeyNodeBase? _primaryKeyNode;
-        
+
+        string? IBatchGetItemBuilder.TableName { get; set; }
+
         public BatchGetItemBuilder()
         {
         }
 
-        private BatchGetItemBuilder(PrimaryKeyNodeBase? primaryKeyNode)
+        private BatchGetItemBuilder(PrimaryKeyNodeBase primaryKeyNode)
         {
             _primaryKeyNode = primaryKeyNode;
         }

--- a/src/EfficientDynamoDb/Operations/BatchGetItem/BatchGetItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchGetItem/BatchGetItemBuilder.cs
@@ -4,17 +4,17 @@ using EfficientDynamoDb.Operations.Query;
 
 namespace EfficientDynamoDb.Operations.BatchGetItem
 {
-    internal sealed class BatchGetItemBuilder<TEntity> : IBatchGetItemBuilder where TEntity : class
+    internal class BatchGetItemBuilder<TEntity> : IBatchGetItemBuilder where TEntity : class
     {
         private readonly PrimaryKeyNodeBase? _primaryKeyNode;
 
-        string? IBatchGetItemBuilder.TableName { get; set; }
+        string? IBatchGetItemBuilder.TableName => GetTableName();
 
         public BatchGetItemBuilder()
         {
         }
 
-        private BatchGetItemBuilder(PrimaryKeyNodeBase primaryKeyNode)
+        protected BatchGetItemBuilder(PrimaryKeyNodeBase primaryKeyNode)
         {
             _primaryKeyNode = primaryKeyNode;
         }
@@ -23,10 +23,29 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
 
         Type IBatchGetItemBuilder.GetEntityType() => typeof(TEntity);
 
+        IBatchGetItemBuilder IBatchGetItemBuilder.WithTableName(string tableName)
+        {
+            throw new NotImplementedException();
+        }
+
         public IBatchGetItemBuilder WithPrimaryKey<TPk, TSk>(TPk pk, TSk sk) =>
             new BatchGetItemBuilder<TEntity>(new PartitionAndSortKeyNode<TPk, TSk>(pk, sk, null));
 
         public IBatchGetItemBuilder WithPrimaryKey<TPk>(TPk pk)=>
             new BatchGetItemBuilder<TEntity>(new PartitionKeyNode<TPk>(pk, null));
+
+        protected virtual string? GetTableName() => null;
+    }
+
+    internal sealed class BatchGetItemWithTableNameBuilder<TEntity> : BatchGetItemBuilder<TEntity> where TEntity : class
+    {
+        private readonly string _tableName;
+
+        public BatchGetItemWithTableNameBuilder(PrimaryKeyNodeBase primaryKeyNode, string tableName) : base(primaryKeyNode)
+        {
+            _tableName = tableName;
+        }
+
+        protected override string? GetTableName() => _tableName;
     }
 }

--- a/src/EfficientDynamoDb/Operations/BatchGetItem/BatchGetItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchGetItem/BatchGetItemBuilder.cs
@@ -14,7 +14,7 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
         {
         }
 
-        protected BatchGetItemBuilder(PrimaryKeyNodeBase primaryKeyNode)
+        protected BatchGetItemBuilder(PrimaryKeyNodeBase? primaryKeyNode)
         {
             _primaryKeyNode = primaryKeyNode;
         }
@@ -23,15 +23,12 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
 
         Type IBatchGetItemBuilder.GetEntityType() => typeof(TEntity);
 
-        IBatchGetItemBuilder IBatchGetItemBuilder.WithTableName(string tableName)
-        {
-            throw new NotImplementedException();
-        }
+        IBatchGetItemBuilder IBatchGetItemBuilder.WithTableName(string tableName) => new BatchGetItemWithTableNameBuilder<TEntity>(_primaryKeyNode, tableName);
 
-        public IBatchGetItemBuilder WithPrimaryKey<TPk, TSk>(TPk pk, TSk sk) =>
+        public virtual IBatchGetItemBuilder WithPrimaryKey<TPk, TSk>(TPk pk, TSk sk) =>
             new BatchGetItemBuilder<TEntity>(new PartitionAndSortKeyNode<TPk, TSk>(pk, sk, null));
 
-        public IBatchGetItemBuilder WithPrimaryKey<TPk>(TPk pk)=>
+        public virtual IBatchGetItemBuilder WithPrimaryKey<TPk>(TPk pk) =>
             new BatchGetItemBuilder<TEntity>(new PartitionKeyNode<TPk>(pk, null));
 
         protected virtual string? GetTableName() => null;
@@ -41,10 +38,16 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
     {
         private readonly string _tableName;
 
-        public BatchGetItemWithTableNameBuilder(PrimaryKeyNodeBase primaryKeyNode, string tableName) : base(primaryKeyNode)
+        public BatchGetItemWithTableNameBuilder(PrimaryKeyNodeBase? primaryKeyNode, string tableName) : base(primaryKeyNode)
         {
             _tableName = tableName;
         }
+
+        public override IBatchGetItemBuilder WithPrimaryKey<TPk, TSk>(TPk pk, TSk sk) =>
+            new BatchGetItemWithTableNameBuilder<TEntity>(new PartitionAndSortKeyNode<TPk, TSk>(pk, sk, null), _tableName);
+
+        public override IBatchGetItemBuilder WithPrimaryKey<TPk>(TPk pk) =>
+            new BatchGetItemWithTableNameBuilder<TEntity>(new PartitionKeyNode<TPk>(pk, null), _tableName);
 
         protected override string? GetTableName() => _tableName;
     }

--- a/src/EfficientDynamoDb/Operations/BatchGetItem/BatchGetTableBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchGetItem/BatchGetTableBuilder.cs
@@ -3,12 +3,18 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using EfficientDynamoDb.Exceptions;
 using EfficientDynamoDb.Operations.Query;
+using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.BatchGetItem
 {
     internal sealed class BatchGetTableBuilder<TTableEntity> : IBatchGetTableBuilder<TTableEntity> where TTableEntity : class
     {
         private readonly BuilderNode? _node;
+
+        BuilderNode? ITableBuilder<IBatchGetTableBuilder<TTableEntity>>.Node => _node;
+
+        IBatchGetTableBuilder<TTableEntity> ITableBuilder<IBatchGetTableBuilder<TTableEntity>>.Create(BuilderNode newNode)
+            => new BatchGetTableBuilder<TTableEntity>(newNode);
 
         public BatchGetTableBuilder()
         {

--- a/src/EfficientDynamoDb/Operations/BatchGetItem/IBatchGetItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchGetItem/IBatchGetItemBuilder.cs
@@ -1,5 +1,6 @@
 using System;
 using EfficientDynamoDb.Operations.Query;
+using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.BatchGetItem
 {
@@ -8,6 +9,8 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
         internal PrimaryKeyNodeBase GetPrimaryKeyNode();
 
         internal Type GetEntityType();
+        
+        internal string? TableName { get; set; }
         
         IBatchGetItemBuilder WithPrimaryKey<TPk>(TPk pk);
         

--- a/src/EfficientDynamoDb/Operations/BatchGetItem/IBatchGetItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchGetItem/IBatchGetItemBuilder.cs
@@ -10,7 +10,9 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
 
         internal Type GetEntityType();
         
-        internal string? TableName { get; set; }
+        internal string? TableName { get; }
+
+        internal IBatchGetItemBuilder WithTableName(string tableName);
         
         IBatchGetItemBuilder WithPrimaryKey<TPk>(TPk pk);
         

--- a/src/EfficientDynamoDb/Operations/BatchGetItem/IBatchGetItemsRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchGetItem/IBatchGetItemsRequestBuilder.cs
@@ -1,7 +1,0 @@
-namespace EfficientDynamoDb.Operations.BatchGetItem
-{
-    public interface IBatchGetItemsRequestBuilder
-    {
-      
-    }
-}

--- a/src/EfficientDynamoDb/Operations/BatchGetItem/IBatchGetTableBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchGetItem/IBatchGetTableBuilder.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using EfficientDynamoDb.Operations.Query;
+using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.BatchGetItem
 {
@@ -12,7 +13,7 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
         internal Type GetTableType();
     }
     
-    public interface IBatchGetTableBuilder<TTableEntity> : IBatchGetTableBuilder where TTableEntity : class
+    public interface IBatchGetTableBuilder<TTableEntity> : IBatchGetTableBuilder, ITableBuilder<IBatchGetTableBuilder<TTableEntity>> where TTableEntity : class
     {
         IBatchGetTableBuilder<TTableEntity> WithConsistentRead(bool useConsistentRead);
         

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchDeleteItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchDeleteItemBuilder.cs
@@ -4,25 +4,27 @@ using EfficientDynamoDb.Operations.Query;
 
 namespace EfficientDynamoDb.Operations.BatchWriteItem
 {
-    internal sealed class BatchDeleteItemBuilder : IBatchDeleteItemBuilder
+    internal class BatchDeleteItemBuilder : IBatchDeleteItemBuilder
     {
         private readonly Type _entityType;
         private readonly PrimaryKeyNodeBase? _primaryKeyNode;
 
-        string? IBatchWriteBuilder.TableName { get; set; }
+        string? IBatchWriteBuilder.TableName => GetTableName();
+        
+        BuilderNodeType IBatchWriteBuilder.NodeType => BuilderNodeType.PrimaryKey;
 
         public BatchDeleteItemBuilder(Type entityType)
         {
             _entityType = entityType;
         }
         
-        private BatchDeleteItemBuilder(Type entityType, PrimaryKeyNodeBase? primaryKeyNode)
+        protected BatchDeleteItemBuilder(Type entityType, PrimaryKeyNodeBase? primaryKeyNode)
         {
             _entityType = entityType;
             _primaryKeyNode = primaryKeyNode;
         }
 
-        BuilderNodeType IBatchWriteBuilder.NodeType => BuilderNodeType.PrimaryKey;
+        IBatchDeleteItemBuilder IBatchDeleteItemBuilder.WithTableName(string tableName) => new BatchDeleteItemWithTableNameBuilder(_entityType, _primaryKeyNode, tableName);
 
         Type IBatchWriteBuilder.GetEntityType() => _entityType;
 
@@ -30,6 +32,20 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
 
         public IBatchWriteBuilder WithPrimaryKey<TPk>(TPk pk) => new BatchDeleteItemBuilder(_entityType, new PartitionKeyNode<TPk>(pk, null));
 
+        protected virtual string? GetTableName() => null;
+
         internal PrimaryKeyNodeBase GetPrimaryKeyNode() => _primaryKeyNode ?? throw new DdbException("Can't execute empty batch delete item request.");
+    }
+
+    internal sealed class BatchDeleteItemWithTableNameBuilder : BatchDeleteItemBuilder
+    {
+        private readonly string _tableName;
+
+        public BatchDeleteItemWithTableNameBuilder(Type entityType, PrimaryKeyNodeBase? primaryKeyNode, string tableName) : base(entityType, primaryKeyNode)
+        {
+            _tableName = tableName;
+        }
+
+        protected override string? GetTableName() => _tableName;
     }
 }

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchDeleteItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchDeleteItemBuilder.cs
@@ -9,6 +9,8 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
         private readonly Type _entityType;
         private readonly PrimaryKeyNodeBase? _primaryKeyNode;
 
+        string? IBatchWriteBuilder.TableName { get; set; }
+
         public BatchDeleteItemBuilder(Type entityType)
         {
             _entityType = entityType;

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchDeleteItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchDeleteItemBuilder.cs
@@ -6,8 +6,8 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
 {
     internal class BatchDeleteItemBuilder : IBatchDeleteItemBuilder
     {
-        private readonly Type _entityType;
         private readonly PrimaryKeyNodeBase? _primaryKeyNode;
+        protected readonly Type EntityType;
 
         string? IBatchWriteBuilder.TableName => GetTableName();
         
@@ -15,22 +15,22 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
 
         public BatchDeleteItemBuilder(Type entityType)
         {
-            _entityType = entityType;
+            EntityType = entityType;
         }
         
         protected BatchDeleteItemBuilder(Type entityType, PrimaryKeyNodeBase? primaryKeyNode)
         {
-            _entityType = entityType;
+            EntityType = entityType;
             _primaryKeyNode = primaryKeyNode;
         }
 
-        IBatchDeleteItemBuilder IBatchDeleteItemBuilder.WithTableName(string tableName) => new BatchDeleteItemWithTableNameBuilder(_entityType, _primaryKeyNode, tableName);
+        IBatchDeleteItemBuilder IBatchDeleteItemBuilder.WithTableName(string tableName) => new BatchDeleteItemWithTableNameBuilder(EntityType, _primaryKeyNode, tableName);
 
-        Type IBatchWriteBuilder.GetEntityType() => _entityType;
+        Type IBatchWriteBuilder.GetEntityType() => EntityType;
 
-        public IBatchWriteBuilder WithPrimaryKey<TPk, TSk>(TPk pk, TSk sk) => new BatchDeleteItemBuilder(_entityType, new PartitionAndSortKeyNode<TPk, TSk>(pk, sk, null));
+        public virtual IBatchWriteBuilder WithPrimaryKey<TPk, TSk>(TPk pk, TSk sk) => new BatchDeleteItemBuilder(EntityType, new PartitionAndSortKeyNode<TPk, TSk>(pk, sk, null));
 
-        public IBatchWriteBuilder WithPrimaryKey<TPk>(TPk pk) => new BatchDeleteItemBuilder(_entityType, new PartitionKeyNode<TPk>(pk, null));
+        public virtual IBatchWriteBuilder WithPrimaryKey<TPk>(TPk pk) => new BatchDeleteItemBuilder(EntityType, new PartitionKeyNode<TPk>(pk, null));
 
         protected virtual string? GetTableName() => null;
 
@@ -45,6 +45,11 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
         {
             _tableName = tableName;
         }
+
+        public override IBatchWriteBuilder WithPrimaryKey<TPk, TSk>(TPk pk, TSk sk) =>
+            new BatchDeleteItemWithTableNameBuilder(EntityType, new PartitionAndSortKeyNode<TPk, TSk>(pk, sk, null), _tableName);
+
+        public override IBatchWriteBuilder WithPrimaryKey<TPk>(TPk pk) => new BatchDeleteItemWithTableNameBuilder(EntityType, new PartitionKeyNode<TPk>(pk, null), _tableName);
 
         protected override string? GetTableName() => _tableName;
     }

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchPutItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchPutItemBuilder.cs
@@ -3,10 +3,12 @@ using EfficientDynamoDb.Operations.Query;
 
 namespace EfficientDynamoDb.Operations.BatchWriteItem
 {
-    internal sealed class BatchPutItemBuilder : IBatchWriteBuilder
+    internal sealed class BatchPutItemBuilder : IBatchPutItemBuilder
     {
         private readonly Type _entityType;
         internal readonly object Entity;
+        
+        string? IBatchWriteBuilder.TableName { get; set; }
 
         public BatchPutItemBuilder(Type entityType, object entity)
         {

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchPutItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchPutItemBuilder.cs
@@ -3,21 +3,37 @@ using EfficientDynamoDb.Operations.Query;
 
 namespace EfficientDynamoDb.Operations.BatchWriteItem
 {
-    internal sealed class BatchPutItemBuilder : IBatchPutItemBuilder
+    internal class BatchPutItemBuilder : IBatchPutItemBuilder
     {
         private readonly Type _entityType;
         internal readonly object Entity;
+
+        string? IBatchWriteBuilder.TableName => GetTableName();
         
-        string? IBatchWriteBuilder.TableName { get; set; }
+        BuilderNodeType IBatchWriteBuilder.NodeType => BuilderNodeType.Item;
 
         public BatchPutItemBuilder(Type entityType, object entity)
         {
             _entityType = entityType;
             Entity = entity;
         }
-
-        BuilderNodeType IBatchWriteBuilder.NodeType => BuilderNodeType.Item;
-
+        
         Type IBatchWriteBuilder.GetEntityType() => _entityType;
+
+        IBatchPutItemBuilder IBatchPutItemBuilder.WithTableName(string tableName) => new BatchPutItemWithTableNameBuilder(_entityType, Entity, tableName);
+        
+        protected virtual string? GetTableName() => null;
+    }
+
+    internal sealed class BatchPutItemWithTableNameBuilder : BatchPutItemBuilder
+    {
+        private readonly string _tableName;
+
+        public BatchPutItemWithTableNameBuilder(Type entityType, object entity, string tableName) : base(entityType, entity)
+        {
+            _tableName = tableName;
+        }
+
+        protected override string? GetTableName() => _tableName;
     }
 }

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchDeleteItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchDeleteItemBuilder.cs
@@ -1,3 +1,5 @@
+using EfficientDynamoDb.Operations.Shared;
+
 namespace EfficientDynamoDb.Operations.BatchWriteItem
 {
     public interface IBatchDeleteItemBuilder : IBatchWriteBuilder

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchDeleteItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchDeleteItemBuilder.cs
@@ -7,5 +7,7 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
         IBatchWriteBuilder WithPrimaryKey<TPk, TSk>(TPk pk, TSk sk);
         
         IBatchWriteBuilder WithPrimaryKey<TPk>(TPk pk);
+
+        internal IBatchDeleteItemBuilder WithTableName(string tableName);
     }
 }

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchPutItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchPutItemBuilder.cs
@@ -1,0 +1,7 @@
+﻿namespace EfficientDynamoDb.Operations.BatchWriteItem
+{
+    public interface IBatchPutItemBuilder : IBatchWriteBuilder
+    {
+        
+    }
+}

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchPutItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchPutItemBuilder.cs
@@ -2,6 +2,6 @@
 {
     public interface IBatchPutItemBuilder : IBatchWriteBuilder
     {
-        
+        internal IBatchPutItemBuilder WithTableName(string tableName);
     }
 }

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchWriteBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchWriteBuilder.cs
@@ -6,6 +6,8 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
     public interface IBatchWriteBuilder
     {
         internal BuilderNodeType NodeType { get; }
+        
+        internal string? TableName { get; set; }
 
         internal Type GetEntityType();
     }

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchWriteBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchWriteBuilder.cs
@@ -7,7 +7,7 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
     {
         internal BuilderNodeType NodeType { get; }
         
-        internal string? TableName { get; set; }
+        internal string? TableName { get; }
 
         internal Type GetEntityType();
     }

--- a/src/EfficientDynamoDb/Operations/DeleteItem/DeleteItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/DeleteItem/DeleteItemRequestBuilder.cs
@@ -14,6 +14,11 @@ namespace EfficientDynamoDb.Operations.DeleteItem
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
 
+        BuilderNode? ITableBuilder<IDeleteItemEntityRequestBuilder<TEntity>>.Node => _node;
+
+        IDeleteItemEntityRequestBuilder<TEntity> ITableBuilder<IDeleteItemEntityRequestBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new DeleteItemEntityRequestBuilder<TEntity>(_context, newNode);
+
         public DeleteItemEntityRequestBuilder(DynamoDbContext context)
         {
             _context = context;
@@ -73,6 +78,11 @@ namespace EfficientDynamoDb.Operations.DeleteItem
     {
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
+
+        BuilderNode? ITableBuilder<IDeleteItemDocumentRequestBuilder<TEntity>>.Node => _node;
+
+        IDeleteItemDocumentRequestBuilder<TEntity> ITableBuilder<IDeleteItemDocumentRequestBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new DeleteItemDocumentRequestBuilder<TEntity>(_context, newNode);
 
         public DeleteItemDocumentRequestBuilder(DynamoDbContext context)
         {

--- a/src/EfficientDynamoDb/Operations/DeleteItem/IDeleteItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/DeleteItem/IDeleteItemRequestBuilder.cs
@@ -7,7 +7,7 @@ using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.DeleteItem
 {
-    public interface IDeleteItemEntityRequestBuilder<TEntity> where TEntity : class
+    public interface IDeleteItemEntityRequestBuilder<TEntity> : ITableBuilder<IDeleteItemEntityRequestBuilder<TEntity>> where TEntity : class
     {
         IDeleteItemEntityRequestBuilder<TEntity> WithCondition(FilterBase condition);
 
@@ -32,7 +32,7 @@ namespace EfficientDynamoDb.Operations.DeleteItem
         Task<DeleteItemEntityResponse<TEntity>> ToResponseAsync(CancellationToken cancellationToken = default);
     }
     
-    public interface IDeleteItemDocumentRequestBuilder<TEntity> where TEntity : class
+    public interface IDeleteItemDocumentRequestBuilder<TEntity> : ITableBuilder<IDeleteItemDocumentRequestBuilder<TEntity>> where TEntity : class
     {
         IDeleteItemDocumentRequestBuilder<TEntity> WithCondition(FilterBase condition);
 

--- a/src/EfficientDynamoDb/Operations/GetItem/GetItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/GetItem/GetItemRequestBuilder.cs
@@ -14,6 +14,11 @@ namespace EfficientDynamoDb.Operations.GetItem
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
 
+        BuilderNode? ITableBuilder<IGetItemEntityRequestBuilder<TEntity>>.Node => _node;
+
+        IGetItemEntityRequestBuilder<TEntity> ITableBuilder<IGetItemEntityRequestBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new GetItemEntityRequestBuilder<TEntity>(_context, newNode);
+
         public GetItemEntityRequestBuilder(DynamoDbContext context)
         {
             _context = context;
@@ -68,6 +73,11 @@ namespace EfficientDynamoDb.Operations.GetItem
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
 
+        BuilderNode? ITableBuilder<IGetItemEntityRequestBuilder<TEntity, TProjection>>.Node => _node;
+
+        IGetItemEntityRequestBuilder<TEntity, TProjection> ITableBuilder<IGetItemEntityRequestBuilder<TEntity, TProjection>>.Create(BuilderNode newNode)
+            => new GetItemEntityRequestBuilder<TEntity, TProjection>(_context, newNode);
+
         public GetItemEntityRequestBuilder(DynamoDbContext context)
         {
             _context = context;
@@ -112,6 +122,11 @@ namespace EfficientDynamoDb.Operations.GetItem
     {
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
+
+        BuilderNode? ITableBuilder<IGetItemDocumentRequestBuilder<TEntity>>.Node => _node;
+
+        IGetItemDocumentRequestBuilder<TEntity> ITableBuilder<IGetItemDocumentRequestBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new GetItemDocumentRequestBuilder<TEntity>(_context, newNode);
 
         public GetItemDocumentRequestBuilder(DynamoDbContext context)
         {

--- a/src/EfficientDynamoDb/Operations/GetItem/IGetItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/GetItem/IGetItemRequestBuilder.cs
@@ -7,7 +7,7 @@ using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.GetItem
 {
-    public interface IGetItemEntityRequestBuilder<TEntity> where TEntity : class
+    public interface IGetItemEntityRequestBuilder<TEntity> : ITableBuilder<IGetItemEntityRequestBuilder<TEntity>> where TEntity : class
     {
         IGetItemEntityRequestBuilder<TEntity> WithConsistentRead(bool useConsistentRead);
 
@@ -30,7 +30,7 @@ namespace EfficientDynamoDb.Operations.GetItem
         Task<GetItemEntityResponse<TEntity>> ToResponseAsync(CancellationToken cancellationToken = default);
     }
     
-    public interface IGetItemEntityRequestBuilder<TEntity, TProjection> where TEntity : class where TProjection : class
+    public interface IGetItemEntityRequestBuilder<TEntity, TProjection> : ITableBuilder<IGetItemEntityRequestBuilder<TEntity, TProjection>> where TEntity : class where TProjection : class
     {
         IGetItemEntityRequestBuilder<TEntity, TProjection> WithConsistentRead(bool useConsistentRead);
 
@@ -47,7 +47,7 @@ namespace EfficientDynamoDb.Operations.GetItem
         Task<GetItemEntityResponse<TProjection>> ToResponseAsync(CancellationToken cancellationToken = default);
     }
     
-    public interface IGetItemDocumentRequestBuilder<TEntity> where TEntity : class
+    public interface IGetItemDocumentRequestBuilder<TEntity> : ITableBuilder<IGetItemDocumentRequestBuilder<TEntity>> where TEntity : class
     {
         IGetItemDocumentRequestBuilder<TEntity> WithConsistentRead(bool useConsistentRead);
         

--- a/src/EfficientDynamoDb/Operations/PutItem/IPutItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/PutItem/IPutItemRequestBuilder.cs
@@ -7,7 +7,7 @@ using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.PutItem
 {
-    public interface IPutItemRequestBuilder
+    public interface IPutItemRequestBuilder : ITableBuilder<IPutItemRequestBuilder>
     {
         IPutItemEntityRequestBuilder<TEntity> WithItem<TEntity>(TEntity item) where TEntity : class;
         
@@ -20,7 +20,7 @@ namespace EfficientDynamoDb.Operations.PutItem
         IPutItemRequestBuilder WithCondition(FilterBase condition);
     }
     
-    public interface IPutItemEntityRequestBuilder<TEntity> where TEntity: class
+    public interface IPutItemEntityRequestBuilder<TEntity> : ITableBuilder<IPutItemEntityRequestBuilder<TEntity>> where TEntity: class
     {
         IPutItemEntityRequestBuilder<TEntity> WithReturnValues(ReturnValues returnValues);
         
@@ -41,7 +41,7 @@ namespace EfficientDynamoDb.Operations.PutItem
         Task<PutItemEntityResponse<TEntity>> ToResponseAsync(CancellationToken cancellationToken = default);
     }
     
-    public interface IPutItemDocumentRequestBuilder<TEntity> where TEntity: class
+    public interface IPutItemDocumentRequestBuilder<TEntity> : ITableBuilder<IPutItemDocumentRequestBuilder<TEntity>> where TEntity: class
     {
         IPutItemDocumentRequestBuilder<TEntity> WithReturnValues(ReturnValues returnValues);
         

--- a/src/EfficientDynamoDb/Operations/PutItem/PutItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/PutItem/PutItemRequestBuilder.cs
@@ -13,6 +13,11 @@ namespace EfficientDynamoDb.Operations.PutItem
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
 
+        BuilderNode? ITableBuilder<IPutItemRequestBuilder>.Node => _node;
+
+        IPutItemRequestBuilder ITableBuilder<IPutItemRequestBuilder>.Create(BuilderNode newNode)
+            => new PutItemRequestBuilder(_context, newNode);
+
         public PutItemRequestBuilder(DynamoDbContext context) => _context = context;
 
         private PutItemRequestBuilder(DynamoDbContext context, BuilderNode? node)
@@ -41,6 +46,11 @@ namespace EfficientDynamoDb.Operations.PutItem
     {
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
+
+        BuilderNode? ITableBuilder<IPutItemEntityRequestBuilder<TEntity>>.Node => _node;
+
+        IPutItemEntityRequestBuilder<TEntity> ITableBuilder<IPutItemEntityRequestBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new PutItemEntityRequestBuilder<TEntity>(_context, newNode);
 
         public PutItemEntityRequestBuilder(DynamoDbContext context) => _context = context;
 
@@ -81,6 +91,11 @@ namespace EfficientDynamoDb.Operations.PutItem
     {
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
+
+        BuilderNode? ITableBuilder<IPutItemDocumentRequestBuilder<TEntity>>.Node => _node;
+
+        IPutItemDocumentRequestBuilder<TEntity> ITableBuilder<IPutItemDocumentRequestBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new PutItemDocumentRequestBuilder<TEntity>(_context, newNode);
 
         public PutItemDocumentRequestBuilder(DynamoDbContext context) => _context = context;
 

--- a/src/EfficientDynamoDb/Operations/Query/IQueryRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/Query/IQueryRequestBuilder.cs
@@ -10,7 +10,7 @@ using EfficientDynamoDb.Operations.Shared;
 namespace EfficientDynamoDb.Operations.Query
 {
 
-    public interface IQueryEntityRequestBuilder<TEntity> where TEntity : class
+    public interface IQueryEntityRequestBuilder<TEntity> : ITableBuilder<IQueryEntityRequestBuilder<TEntity>> where TEntity : class
     {
         Task<IReadOnlyList<TEntity>> ToListAsync(CancellationToken cancellationToken = default);
 
@@ -51,7 +51,7 @@ namespace EfficientDynamoDb.Operations.Query
         IQueryEntityRequestBuilder<TEntity> WithProjectedAttributes(params Expression<Func<TEntity, object>>[] properties);
     }
     
-     public interface IQueryEntityRequestBuilder<TEntity, TProjection> where TEntity : class where TProjection : class
+     public interface IQueryEntityRequestBuilder<TEntity, TProjection> : ITableBuilder<IQueryEntityRequestBuilder<TEntity, TProjection>> where TEntity : class where TProjection : class
     {
         Task<IReadOnlyList<TProjection>> ToListAsync(CancellationToken cancellationToken = default);
         
@@ -86,7 +86,7 @@ namespace EfficientDynamoDb.Operations.Query
         IQueryEntityRequestBuilder<TEntity, TProjection> WithPaginationToken(string? paginationToken);
     }
     
-    public interface IQueryDocumentRequestBuilder<TEntity> where TEntity : class
+    public interface IQueryDocumentRequestBuilder<TEntity> : ITableBuilder<IQueryDocumentRequestBuilder<TEntity>> where TEntity : class
     {
         Task<IReadOnlyList<Document>> ToListAsync(CancellationToken cancellationToken = default);
         

--- a/src/EfficientDynamoDb/Operations/Query/QueryRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/Query/QueryRequestBuilder.cs
@@ -16,6 +16,11 @@ namespace EfficientDynamoDb.Operations.Query
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
 
+        BuilderNode? ITableBuilder<IQueryEntityRequestBuilder<TEntity>>.Node => _node;
+
+        IQueryEntityRequestBuilder<TEntity> ITableBuilder<IQueryEntityRequestBuilder<TEntity>>.Create(BuilderNode newNode) =>
+            new QueryEntityRequestBuilder<TEntity>(_context, newNode);
+
         public QueryEntityRequestBuilder(DynamoDbContext context)
         {
             _context = context;
@@ -92,7 +97,7 @@ namespace EfficientDynamoDb.Operations.Query
 
         public IQueryEntityRequestBuilder<TEntity> WithProjectedAttributes(params Expression<Func<TEntity, object>>[] properties) =>
             new QueryEntityRequestBuilder<TEntity>(_context, new ProjectedAttributesNode(typeof(TEntity), properties, _node));
-        
+
         private BuilderNode GetNode() => _node ?? throw new DdbException("Can't execute empty query request.");
     }
     
@@ -100,6 +105,11 @@ namespace EfficientDynamoDb.Operations.Query
     {
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
+
+        BuilderNode? ITableBuilder<IQueryEntityRequestBuilder<TEntity, TProjection>>.Node => _node;
+
+        IQueryEntityRequestBuilder<TEntity, TProjection> ITableBuilder<IQueryEntityRequestBuilder<TEntity, TProjection>>.Create(BuilderNode newNode) =>
+            new QueryEntityRequestBuilder<TEntity, TProjection>(_context, newNode);
 
         public QueryEntityRequestBuilder(DynamoDbContext context)
         {
@@ -178,6 +188,11 @@ namespace EfficientDynamoDb.Operations.Query
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
 
+        BuilderNode? ITableBuilder<IQueryDocumentRequestBuilder<TEntity>>.Node => _node;
+
+        IQueryDocumentRequestBuilder<TEntity> ITableBuilder<IQueryDocumentRequestBuilder<TEntity>>.Create(BuilderNode newNode) =>
+            new QueryDocumentRequestBuilder<TEntity>(_context, newNode);
+
         public QueryDocumentRequestBuilder(DynamoDbContext context)
         {
             _context = context;
@@ -235,7 +250,6 @@ namespace EfficientDynamoDb.Operations.Query
             new QueryDocumentRequestBuilder<TEntity>(_context, new ConsistentReadNode(useConsistentRead, _node));
 
         public IQueryDocumentRequestBuilder<TEntity> WithLimit(int limit) => new QueryDocumentRequestBuilder<TEntity>(_context, new LimitNode(limit, _node));
-        
 
         public IQueryDocumentRequestBuilder<TEntity> ReturnConsumedCapacity(ReturnConsumedCapacity consumedCapacityMode) =>
             new QueryDocumentRequestBuilder<TEntity>(_context, new ReturnConsumedCapacityNode(consumedCapacityMode, _node));

--- a/src/EfficientDynamoDb/Operations/Scan/IScanRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/Scan/IScanRequestBuilder.cs
@@ -9,7 +9,7 @@ using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.Scan
 {
-    public interface IScanEntityRequestBuilder<TEntity> where TEntity : class
+    public interface IScanEntityRequestBuilder<TEntity> : ITableBuilder<IScanEntityRequestBuilder<TEntity>> where TEntity : class
     {
         IScanEntityRequestBuilder<TEntity> FromIndex(string indexName);
 
@@ -46,7 +46,7 @@ namespace EfficientDynamoDb.Operations.Scan
         Task<ScanEntityResponse<TEntity>> ToResponseAsync(CancellationToken cancellationToken = default);
     }
     
-    public interface IScanEntityRequestBuilder<TEntity, TProjection> where TEntity : class where TProjection : class
+    public interface IScanEntityRequestBuilder<TEntity, TProjection> : ITableBuilder<IScanEntityRequestBuilder<TEntity, TProjection>> where TEntity : class where TProjection : class
     {
         IScanEntityRequestBuilder<TEntity, TProjection> FromIndex(string indexName);
 
@@ -77,7 +77,7 @@ namespace EfficientDynamoDb.Operations.Scan
         Task<ScanEntityResponse<TProjection>> ToResponseAsync(CancellationToken cancellationToken = default);
     }
     
-    public interface IScanDocumentRequestBuilder<TEntity> where TEntity : class
+    public interface IScanDocumentRequestBuilder<TEntity> : ITableBuilder<IScanDocumentRequestBuilder<TEntity>> where TEntity : class
     {
         IScanDocumentRequestBuilder<TEntity> FromIndex(string indexName);
 

--- a/src/EfficientDynamoDb/Operations/Scan/ScanRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/Scan/ScanRequestBuilder.cs
@@ -16,6 +16,11 @@ namespace EfficientDynamoDb.Operations.Scan
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
 
+        BuilderNode? ITableBuilder<IScanEntityRequestBuilder<TEntity>>.Node => _node;
+
+        IScanEntityRequestBuilder<TEntity> ITableBuilder<IScanEntityRequestBuilder<TEntity>>.Create(BuilderNode newNode) =>
+            new ScanEntityRequestBuilder<TEntity>(_context, newNode);
+
         public ScanEntityRequestBuilder(DynamoDbContext context)
         {
             _context = context;
@@ -94,6 +99,11 @@ namespace EfficientDynamoDb.Operations.Scan
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
 
+        BuilderNode? ITableBuilder<IScanEntityRequestBuilder<TEntity, TProjection>>.Node => _node;
+
+        IScanEntityRequestBuilder<TEntity, TProjection> ITableBuilder<IScanEntityRequestBuilder<TEntity, TProjection>>.Create(BuilderNode newNode) =>
+            new ScanEntityRequestBuilder<TEntity, TProjection>(_context, newNode);
+
         public ScanEntityRequestBuilder(DynamoDbContext context)
         {
             _context = context;
@@ -162,6 +172,11 @@ namespace EfficientDynamoDb.Operations.Scan
     {
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
+
+        BuilderNode? ITableBuilder<IScanDocumentRequestBuilder<TEntity>>.Node => _node;
+
+        IScanDocumentRequestBuilder<TEntity> ITableBuilder<IScanDocumentRequestBuilder<TEntity>>.Create(BuilderNode newNode) =>
+            new ScanDocumentRequestBuilder<TEntity>(_context, newNode);
 
         public ScanDocumentRequestBuilder(DynamoDbContext context)
         {

--- a/src/EfficientDynamoDb/Operations/Shared/ITableBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/Shared/ITableBuilder.cs
@@ -1,0 +1,11 @@
+using EfficientDynamoDb.Operations.Query;
+
+namespace EfficientDynamoDb.Operations.Shared
+{
+    public interface ITableBuilder<out TBuilder> where TBuilder : ITableBuilder<TBuilder>
+    {
+        internal BuilderNode? Node { get; }
+
+        internal TBuilder Create(BuilderNode newNode);
+    }
+}

--- a/src/EfficientDynamoDb/Operations/TransactGetItems/ITransactGetItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/TransactGetItems/ITransactGetItemRequestBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq.Expressions;
 using EfficientDynamoDb.Operations.Query;
+using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.TransactGetItems
 {
@@ -11,7 +12,7 @@ namespace EfficientDynamoDb.Operations.TransactGetItems
         internal Type GetEntityType();
     }
     
-    public interface ITransactGetItemRequestBuilder<TEntity> : ITransactGetItemRequestBuilder where TEntity : class
+    public interface ITransactGetItemRequestBuilder<TEntity> : ITransactGetItemRequestBuilder, ITableBuilder<ITransactGetItemRequestBuilder<TEntity>> where TEntity : class
     {
         ITransactGetItemRequestBuilder<TEntity> WithPrimaryKey<TPk>(TPk pk);
         

--- a/src/EfficientDynamoDb/Operations/TransactGetItems/TransactGetItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/TransactGetItems/TransactGetItemRequestBuilder.cs
@@ -2,12 +2,18 @@ using System;
 using System.Linq.Expressions;
 using EfficientDynamoDb.Exceptions;
 using EfficientDynamoDb.Operations.Query;
+using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.TransactGetItems
 {
     internal sealed class TransactGetItemRequestBuilder<TEntity> : ITransactGetItemRequestBuilder<TEntity> where TEntity : class
     {
         private readonly BuilderNode? _node;
+
+        BuilderNode? ITableBuilder<ITransactGetItemRequestBuilder<TEntity>>.Node => _node;
+
+        ITransactGetItemRequestBuilder<TEntity> ITableBuilder<ITransactGetItemRequestBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new TransactGetItemRequestBuilder<TEntity>(newNode);
 
         public TransactGetItemRequestBuilder()
         {

--- a/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/ITransactConditionCheckBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/ITransactConditionCheckBuilder.cs
@@ -4,7 +4,7 @@ using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.TransactWriteItems.Builders
 {
-    public interface ITransactConditionCheckBuilder<TEntity> : ITransactWriteItemBuilder where TEntity : class
+    public interface ITransactConditionCheckBuilder<TEntity> : ITransactWriteItemBuilder, ITableBuilder<ITransactConditionCheckBuilder<TEntity>> where TEntity : class
     {
         ITransactConditionCheckBuilder<TEntity> WithPrimaryKey<TPk>(TPk pk);
 

--- a/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/ITransactDeleteItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/ITransactDeleteItemBuilder.cs
@@ -4,7 +4,7 @@ using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.TransactWriteItems.Builders
 {
-    public interface ITransactDeleteItemBuilder<TEntity> : ITransactWriteItemBuilder where TEntity : class
+    public interface ITransactDeleteItemBuilder<TEntity> : ITransactWriteItemBuilder, ITableBuilder<ITransactDeleteItemBuilder<TEntity>> where TEntity : class
     {
         ITransactDeleteItemBuilder<TEntity> WithPrimaryKey<TPk>(TPk pk);
 

--- a/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/ITransactPutItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/ITransactPutItemBuilder.cs
@@ -4,7 +4,7 @@ using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.TransactWriteItems.Builders
 {
-    public interface ITransactPutItemBuilder<TEntity> : ITransactWriteItemBuilder where TEntity : class
+    public interface ITransactPutItemBuilder<TEntity> : ITransactWriteItemBuilder, ITableBuilder<ITransactPutItemBuilder<TEntity>> where TEntity : class
     {
         ITransactPutItemBuilder<TEntity> WithCondition(FilterBase condition);
 

--- a/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/TransactConditionCheckBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/TransactConditionCheckBuilder.cs
@@ -9,6 +9,11 @@ namespace EfficientDynamoDb.Operations.TransactWriteItems.Builders
     {
         protected override BuilderNodeType NodeType => BuilderNodeType.TransactConditionCheckNode;
 
+        BuilderNode? ITableBuilder<ITransactConditionCheckBuilder<TEntity>>.Node => Node;
+
+        ITransactConditionCheckBuilder<TEntity> ITableBuilder<ITransactConditionCheckBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new TransactConditionCheckBuilder<TEntity>(newNode);
+
         public TransactConditionCheckBuilder()
         {
         }

--- a/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/TransactDeleteItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/TransactDeleteItemBuilder.cs
@@ -9,6 +9,11 @@ namespace EfficientDynamoDb.Operations.TransactWriteItems.Builders
     {
         protected override BuilderNodeType NodeType => BuilderNodeType.TransactDeleteItemNode;
 
+        BuilderNode? ITableBuilder<ITransactDeleteItemBuilder<TEntity>>.Node => Node;
+
+        ITransactDeleteItemBuilder<TEntity> ITableBuilder<ITransactDeleteItemBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new TransactDeleteItemBuilder<TEntity>(newNode);
+
         public TransactDeleteItemBuilder()
         {
         }

--- a/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/TransactPutItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/TransactPutItemBuilder.cs
@@ -9,6 +9,11 @@ namespace EfficientDynamoDb.Operations.TransactWriteItems.Builders
     {
         protected override BuilderNodeType NodeType => BuilderNodeType.TransactPutItemNode;
 
+        BuilderNode? ITableBuilder<ITransactPutItemBuilder<TEntity>>.Node => Node;
+
+        ITransactPutItemBuilder<TEntity> ITableBuilder<ITransactPutItemBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new TransactPutItemBuilder<TEntity>(newNode);
+
         public TransactPutItemBuilder()
         {
         }

--- a/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/TransactUpdateItemBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/TransactWriteItems/Builders/TransactUpdateItemBuilder.cs
@@ -11,6 +11,11 @@ namespace EfficientDynamoDb.Operations.TransactWriteItems.Builders
     {
         protected override BuilderNodeType NodeType => BuilderNodeType.TransactUpdateItemNode;
 
+        BuilderNode? ITableBuilder<ITransactUpdateItemBuilder<TEntity>>.Node => Node;
+
+        ITransactUpdateItemBuilder<TEntity> ITableBuilder<ITransactUpdateItemBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new TransactUpdateItemBuilder<TEntity>(newNode);
+
         public TransactUpdateItemBuilder()
         {
         }

--- a/src/EfficientDynamoDb/Operations/UpdateItem/UpdateRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/UpdateItem/UpdateRequestBuilder.cs
@@ -15,6 +15,11 @@ namespace EfficientDynamoDb.Operations.UpdateItem
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
 
+        BuilderNode? ITableBuilder<IUpdateEntityRequestBuilder<TEntity>>.Node => _node;
+
+        IUpdateEntityRequestBuilder<TEntity> ITableBuilder<IUpdateEntityRequestBuilder<TEntity>>.Create(BuilderNode newNode) 
+            => new UpdateEntityRequestBuilder<TEntity>(_context, newNode);
+
         public UpdateEntityRequestBuilder(DynamoDbContext context)
         {
             _context = context;
@@ -74,6 +79,11 @@ namespace EfficientDynamoDb.Operations.UpdateItem
     {
         private readonly DynamoDbContext _context;
         private readonly BuilderNode? _node;
+
+        BuilderNode? ITableBuilder<IUpdateDocumentRequestBuilder<TEntity>>.Node => _node;
+
+        IUpdateDocumentRequestBuilder<TEntity> ITableBuilder<IUpdateDocumentRequestBuilder<TEntity>>.Create(BuilderNode newNode)
+            => new UpdateDocumentRequestBuilder<TEntity>(_context, newNode);
 
         public UpdateDocumentRequestBuilder(DynamoDbContext context)
         {

--- a/website/docs/dev_guide/high_level/attributes.md
+++ b/website/docs/dev_guide/high_level/attributes.md
@@ -10,12 +10,14 @@ When using high-level API, data classes have to be marked with certain attribute
 
 Specifies a target table name.
 
-**Required:** true
+**Required:** false
 
 ```csharp
 [DynamoDbTable("users")]
 public class UserEntity { ... }
 ```
+
+If the same entity class needs to be stored in different tables, the table name can be overridden using the `WithTableName` extension method.
 
 Note: *`DynamoDbTable` supports inheritance, can be applied to the base class.*
 


### PR DESCRIPTION
Initial approach addressing #106 

I decided to implement `WithTableName` as an extension method so it is suggested as a last option in the auto-complete. It should also hint that specifying table names explicitly is optional.

There are currently 3 additional extension methods for batch operations because batches have more optimized builders. In case if we add more customization to batch builders, it would make sense to refactor them to `BuilderNode` approach and have a single extension method in the end.