### PR TITLE
Add DocumentJsonSerializer

### DIFF
--- a/src/Benchmarks/Benchmarks/ValueTaskBenchmarks.cs
+++ b/src/Benchmarks/Benchmarks/ValueTaskBenchmarks.cs
@@ -31,7 +31,7 @@ namespace Benchmarks
             
             WriteData(writer, bufferWriter);
 
-            await bufferWriter.WriteToStreamAsync().ConfigureAwait(false);
+            await bufferWriter.FlushAsync(writer).ConfigureAwait(false);
 
             return stream.Length;
         }
@@ -45,7 +45,7 @@ namespace Benchmarks
             
             await WriteDataAsync(writer, bufferWriter).ConfigureAwait(false);
 
-            await bufferWriter.WriteToStreamAsync().ConfigureAwait(false);
+            await bufferWriter.FlushAsync(writer).ConfigureAwait(false);
 
             return stream.Length;
         }
@@ -80,16 +80,16 @@ namespace Benchmarks
         {
             writer.WriteStringValue(attributeValue.Value);
             
-            if (bufferWriter.ShouldWrite(writer))
-                bufferWriter.WriteToStreamAsync();
+            if (bufferWriter.ShouldFlush(writer))
+                bufferWriter.FlushAsync(writer);
         }
         
         private async ValueTask WriteValueAsync(Utf8JsonWriter writer, PooledByteBufferWriter bufferWriter, StringAttributeValue attributeValue)
         {
             writer.WriteStringValue(attributeValue.Value);
             
-            if (bufferWriter.ShouldWrite(writer))
-                await bufferWriter.WriteToStreamAsync().ConfigureAwait(false);
+            if (bufferWriter.ShouldFlush(writer))
+                await bufferWriter.FlushAsync(writer).ConfigureAwait(false);
         }
     }
 }

--- a/src/EfficientDynamoDb/Converters/DdbWriter.cs
+++ b/src/EfficientDynamoDb/Converters/DdbWriter.cs
@@ -18,16 +18,9 @@ namespace EfficientDynamoDb.Converters
             BufferWriter = bufferWriter;
         }
 
-        public bool ShouldFlush => BufferWriter.ShouldWrite(JsonWriter);
+        public bool ShouldFlush => BufferWriter.ShouldFlush(JsonWriter);
 
-        public ValueTask FlushAsync()
-        {
-            // Call sync because we are working with in-memory buffer
-            // ReSharper disable once MethodHasAsyncOverload
-            JsonWriter.Flush();
-            
-            return BufferWriter.WriteToStreamAsync();
-        }
+        public ValueTask FlushAsync() => BufferWriter.FlushAsync(JsonWriter);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteDdbNull()

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using EfficientDynamoDb.DocumentModel;
 using EfficientDynamoDb.Exceptions;
 using EfficientDynamoDb.Internal;
+using EfficientDynamoDb.Internal.Converters.Json;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Reader;
 using static EfficientDynamoDb.DynamoDbLowLevelContext;
@@ -37,7 +38,8 @@ namespace EfficientDynamoDb
             await using var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 
             var expectedCrc = GetExpectedCrc(response);
-            var result = await EntityDdbJsonReader.ReadAsync<TResult>(responseStream, Config.Metadata, expectedCrc.HasValue, cancellationToken).ConfigureAwait(false);
+            var classInfo = Config.Metadata.GetOrAddClassInfo(typeof(TResult), typeof(JsonObjectDdbConverter<TResult>));
+            var result = await EntityDdbJsonReader.ReadAsync<TResult>(responseStream, classInfo, Config.Metadata, expectedCrc.HasValue, cancellationToken: cancellationToken).ConfigureAwait(false);
             
             if (expectedCrc.HasValue && expectedCrc.Value != result.Crc)
                 throw new ChecksumMismatchException();

--- a/src/EfficientDynamoDb/EfficientDynamoDb.csproj.DotSettings
+++ b/src/EfficientDynamoDb/EfficientDynamoDb.csproj.DotSettings
@@ -5,4 +5,5 @@
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=internal_005Creader_005Cddbjsonreader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=internal_005Creader_005Centityddbjsonreader/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=internal_005Csigning_005Cmodels/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=json_005Cinternal/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=operations_005Cshared_005Cenums/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/EfficientDynamoDb/Internal/Converters/IRootDdbConverter.cs
+++ b/src/EfficientDynamoDb/Internal/Converters/IRootDdbConverter.cs
@@ -1,0 +1,9 @@
+using EfficientDynamoDb.Converters;
+
+namespace EfficientDynamoDb.Internal.Converters
+{
+    internal interface IRootDdbConverter<TValue>
+    {
+        bool TryReadRoot(ref DdbReader reader, out TValue value);
+    }
+}

--- a/src/EfficientDynamoDb/Internal/Converters/Json/JsonObjectDdbConverter.cs
+++ b/src/EfficientDynamoDb/Internal/Converters/Json/JsonObjectDdbConverter.cs
@@ -9,7 +9,7 @@ using EfficientDynamoDb.Internal.Reader;
 
 namespace EfficientDynamoDb.Internal.Converters.Json
 {
-    internal sealed class JsonObjectDdbConverter<T> : DdbResumableConverter<T> where T : class
+    internal sealed class JsonObjectDdbConverter<T> : DdbResumableConverter<T>, IRootDdbConverter<T> where T : class
     {
         internal override DdbClassType ClassType => DdbClassType.Object;
 
@@ -23,7 +23,7 @@ namespace EfficientDynamoDb.Internal.Converters.Json
             throw new NotSupportedException("Should never be called.");
         }
 
-        internal bool TryReadRoot(ref DdbReader reader, out T value) => TryRead(ref reader, out value, true);
+        public bool TryReadRoot(ref DdbReader reader, out T value) => TryRead(ref reader, out value, true);
 
         internal override bool TryRead(ref DdbReader reader, out T value) => TryRead(ref reader, out value, false);
 

--- a/src/EfficientDynamoDb/Internal/ErrorHandler.cs
+++ b/src/EfficientDynamoDb/Internal/ErrorHandler.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using EfficientDynamoDb.Exceptions;
+using EfficientDynamoDb.Internal.Converters.Json;
 using EfficientDynamoDb.Internal.Operations.Shared;
 using EfficientDynamoDb.Internal.Reader;
 using EfficientDynamoDb.Operations.Shared;
@@ -46,7 +47,10 @@ namespace EfficientDynamoDb.Internal
                             
                             if (type == "TransactionCanceledException")
                             {
-                                var transactionCancelledResponse = await EntityDdbJsonReader.ReadAsync<TransactionCancelledResponse>(recyclableStream, metadata, false, cancellationToken).ConfigureAwait(false);
+                                var classInfo = metadata.GetOrAddClassInfo(typeof(TransactionCancelledResponse), typeof(JsonObjectDdbConverter<TransactionCancelledResponse>));
+                                var transactionCancelledResponse = await EntityDdbJsonReader
+                                    .ReadAsync<TransactionCancelledResponse>(recyclableStream, classInfo, metadata, false, cancellationToken: cancellationToken)
+                                    .ConfigureAwait(false);
                                 throw new TransactionCanceledException(transactionCancelledResponse.Value!.CancellationReasons, error.Message);
                             }
                             

--- a/src/EfficientDynamoDb/Internal/Extensions/Utf8JsonWriterExtensions.cs
+++ b/src/EfficientDynamoDb/Internal/Extensions/Utf8JsonWriterExtensions.cs
@@ -90,8 +90,8 @@ namespace EfficientDynamoDb.Internal.Extensions
 
                 pair.Value.Write(writer);
 
-                if (bufferWriter.ShouldWrite(writer))
-                    await bufferWriter.WriteToStreamAsync().ConfigureAwait(false);
+                if (bufferWriter.ShouldFlush(writer))
+                    await bufferWriter.FlushAsync(writer).ConfigureAwait(false);
             }
 
             writer.WriteEndObject();

--- a/src/EfficientDynamoDb/Internal/Operations/Shared/DynamoDbHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/Shared/DynamoDbHttpContent.cs
@@ -12,8 +12,6 @@ namespace EfficientDynamoDb.Internal.Operations.Shared
 {
     internal abstract class DynamoDbHttpContent : HttpContent
     {
-        private const int DefaultBufferSize = 16 * 1024;
-        
         internal static readonly RecyclableMemoryStreamManager MemoryStreamManager = new RecyclableMemoryStreamManager();
         private static readonly JsonWriterOptions JsonWriterOptions = new JsonWriterOptions {SkipValidation = true};
         
@@ -62,10 +60,10 @@ namespace EfficientDynamoDb.Internal.Operations.Shared
             // Pooled buffer may seems redundant while reviewing current method, but when passed to json writer it completely changes the write logic.
             // Instead of reallocating new in-memory arrays when json size grows and Flush is not called explicitly - it now uses pooled buffer.
             // With proper flushing logic amount of buffer growths/copies should be zero and amount of memory allocations should be zero as well.
-            using var bufferWriter = new PooledByteBufferWriter(stream, DefaultBufferSize);
+            using var bufferWriter = new PooledByteBufferWriter(stream);
             await using var writer = new Utf8JsonWriter(bufferWriter, JsonWriterOptions);
             var ddbWriter = new DdbWriter(writer, bufferWriter);
-            
+
             await WriteDataAsync(ddbWriter).ConfigureAwait(false);
 
             await ddbWriter.FlushAsync().ConfigureAwait(false);

--- a/src/EfficientDynamoDb/Internal/Reader/EntityDdbJsonReader.cs
+++ b/src/EfficientDynamoDb/Internal/Reader/EntityDdbJsonReader.cs
@@ -6,14 +6,15 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using EfficientDynamoDb.Internal.Crc;
+using EfficientDynamoDb.Internal.Metadata;
 
 namespace EfficientDynamoDb.Internal.Reader
 {
     internal static partial class EntityDdbJsonReader
     {
-        private const int DefaultBufferSize = 16 * 1024;
+        internal const int DefaultBufferSize = 16 * 1024;
         
-        public static async ValueTask<ReadResult<TEntity>> ReadAsync<TEntity>(Stream utf8Json, DynamoDbContextMetadata metadata, bool returnCrc, CancellationToken cancellationToken = default)
+        public static async ValueTask<ReadResult<TEntity>> ReadAsync<TEntity>(Stream utf8Json, DdbClassInfo classInfo, DynamoDbContextMetadata metadata, bool returnCrc, int defaultBufferSize = DefaultBufferSize, CancellationToken cancellationToken = default)
             where TEntity : class
         {
             var readerState = new JsonReaderState();
@@ -22,7 +23,9 @@ namespace EfficientDynamoDb.Internal.Reader
 
             try
             {
-                var buffer = ArrayPool<byte>.Shared.Rent(DefaultBufferSize);
+                readStack.GetCurrent().ClassInfo ??= classInfo;
+                
+                var buffer = ArrayPool<byte>.Shared.Rent(defaultBufferSize);
                 var clearMax = 0;
                 
                 try

--- a/src/EfficientDynamoDb/Internal/Reader/EntityDdbJsonReader/EntityDdbJsonReader.ReadCore.cs
+++ b/src/EfficientDynamoDb/Internal/Reader/EntityDdbJsonReader/EntityDdbJsonReader.ReadCore.cs
@@ -25,9 +25,7 @@ namespace EfficientDynamoDb.Internal.Reader
         private static void ReadCore<T>(ref DdbReader reader) where T : class
         {
             ref var current = ref reader.State.GetCurrent();
-
-            current.ClassInfo ??= reader.State.Metadata.GetOrAddClassInfo(typeof(T), typeof(JsonObjectDdbConverter<T>));
-
+            
             if (current.ObjectState < DdbStackFrameObjectState.StartToken)
             {
                 if (!reader.JsonReaderValue.Read())
@@ -36,7 +34,7 @@ namespace EfficientDynamoDb.Internal.Reader
                 current.ObjectState = DdbStackFrameObjectState.StartToken;
             }
             
-            var converter = (JsonObjectDdbConverter<T>) current.ClassInfo.ConverterBase;
+            var converter = (IRootDdbConverter<T>) current.ClassInfo!.ConverterBase;
 
             if(converter.TryReadRoot(ref reader, out var value))
                 current.ReturnValue = value;

--- a/src/EfficientDynamoDb/Json/DocumentJsonSerializer.Deserialize.cs
+++ b/src/EfficientDynamoDb/Json/DocumentJsonSerializer.Deserialize.cs
@@ -18,22 +18,22 @@ namespace EfficientDynamoDb.Json
         private static readonly DdbClassInfo DocumentClassInfo = EmptyMetadata.GetOrAddClassInfo(typeof(Document), typeof(DocumentJsonRootConverter));
         private static readonly DdbClassInfo DocumentArrayClassInfo = EmptyMetadata.GetOrAddClassInfo(typeof(Document), typeof(DocumentArrayJsonRootConverter));
         
-        public static Document Deserialize(string json)
+        private static Document Deserialize(string json)
         {
             var stringStream = new Utf8StringStream(json);
             return DeserializeAsync(stringStream, Math.Min((int) stringStream.Length, MaxInitialBufferSize)).Result;
         }
         
-        public static IReadOnlyList<Document> DeserializeArray(string json)
+        private static IReadOnlyList<Document> DeserializeArray(string json)
         {
             var stringStream = new Utf8StringStream(json);
             return DeserializeArrayAsync(stringStream, Math.Min((int) stringStream.Length, MaxInitialBufferSize)).Result;
         }
 
-        public static async Task<Document> DeserializeAsync(Stream utf8JsonStream, CancellationToken cancellationToken = default)
+        private static async Task<Document> DeserializeAsync(Stream utf8JsonStream, CancellationToken cancellationToken = default)
             => await DeserializeAsync(utf8JsonStream, EntityDdbJsonReader.DefaultBufferSize, cancellationToken).ConfigureAwait(false);
         
-        public static async Task<IReadOnlyList<Document>> DeserializeArrayAsync(Stream utf8JsonStream, CancellationToken cancellationToken = default)
+        private static async Task<IReadOnlyList<Document>> DeserializeArrayAsync(Stream utf8JsonStream, CancellationToken cancellationToken = default)
             => await DeserializeArrayAsync(utf8JsonStream, EntityDdbJsonReader.DefaultBufferSize, cancellationToken).ConfigureAwait(false);
 
         private static async ValueTask<Document> DeserializeAsync(Stream utf8JsonStream, int defaultBufferSize, CancellationToken cancellationToken = default)

--- a/src/EfficientDynamoDb/Json/DocumentJsonSerializer.Deserialize.cs
+++ b/src/EfficientDynamoDb/Json/DocumentJsonSerializer.Deserialize.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using EfficientDynamoDb.Converters;
+using EfficientDynamoDb.DocumentModel;
+using EfficientDynamoDb.Internal.Metadata;
+using EfficientDynamoDb.Internal.Reader;
+
+namespace EfficientDynamoDb.Json
+{
+    public static partial class DocumentJsonSerializer
+    {
+        private const int MaxInitialBufferSize = 1024 * 1024;
+        private static readonly DynamoDbContextMetadata EmptyMetadata = new DynamoDbContextMetadata(Array.Empty<DdbConverter>());
+        private static readonly DdbClassInfo DocumentClassInfo = EmptyMetadata.GetOrAddClassInfo(typeof(Document), typeof(DocumentJsonRootConverter));
+        private static readonly DdbClassInfo DocumentArrayClassInfo = EmptyMetadata.GetOrAddClassInfo(typeof(Document), typeof(DocumentArrayJsonRootConverter));
+        
+        public static Document Deserialize(string json)
+        {
+            var stringStream = new Utf8StringStream(json);
+            return DeserializeAsync(stringStream, Math.Min((int) stringStream.Length, MaxInitialBufferSize)).Result;
+        }
+        
+        public static IReadOnlyList<Document> DeserializeArray(string json)
+        {
+            var stringStream = new Utf8StringStream(json);
+            return DeserializeArrayAsync(stringStream, Math.Min((int) stringStream.Length, MaxInitialBufferSize)).Result;
+        }
+
+        public static async Task<Document> DeserializeAsync(Stream utf8JsonStream, CancellationToken cancellationToken = default)
+            => await DeserializeAsync(utf8JsonStream, EntityDdbJsonReader.DefaultBufferSize, cancellationToken).ConfigureAwait(false);
+        
+        public static async Task<IReadOnlyList<Document>> DeserializeArrayAsync(Stream utf8JsonStream, CancellationToken cancellationToken = default)
+            => await DeserializeArrayAsync(utf8JsonStream, EntityDdbJsonReader.DefaultBufferSize, cancellationToken).ConfigureAwait(false);
+
+        private static async ValueTask<Document> DeserializeAsync(Stream utf8JsonStream, int defaultBufferSize, CancellationToken cancellationToken = default)
+        {
+            var result = await EntityDdbJsonReader.ReadAsync<Document>(utf8JsonStream, DocumentClassInfo, EmptyMetadata, false, defaultBufferSize, cancellationToken)
+                .ConfigureAwait(false);
+            
+            return result.Value ?? throw new InvalidOperationException("JSON does not contain a valid document.");
+        }
+        
+        private static async ValueTask<IReadOnlyList<Document>> DeserializeArrayAsync(Stream utf8JsonStream, int defaultBufferSize, CancellationToken cancellationToken = default)
+        {
+            var result = await EntityDdbJsonReader.ReadAsync<IReadOnlyList<Document>>(utf8JsonStream, DocumentArrayClassInfo, EmptyMetadata, false, defaultBufferSize, cancellationToken)
+                .ConfigureAwait(false);
+            
+            return result.Value ?? throw new InvalidOperationException("JSON does not contain a valid document.");
+        }
+
+        private sealed class Utf8StringStream : Stream
+        {
+            private readonly string _value;
+
+            public Utf8StringStream(string value)
+            {
+                _value = value;
+                Length = Encoding.UTF8.GetByteCount(value);
+            }
+
+            public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = new CancellationToken())
+            {
+                var left = Length - Position;
+                var toRead = Math.Min((int) left, buffer.Length);
+
+                var bytesRead = Encoding.UTF8.GetBytes(_value.AsSpan((int) Position, toRead), buffer.Span);
+                Position += bytesRead;
+                return new ValueTask<int>(bytesRead);
+            }
+
+            public override void Flush() => throw new NotSupportedException();
+
+            public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+            public override void SetLength(long value) => throw new NotSupportedException();
+
+            public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+            public override bool CanRead => true;
+            public override bool CanSeek => false;
+            public override bool CanWrite => false;
+            
+            public override long Length { get; }
+            
+            public override long Position { get; set; }
+        }
+    }
+}

--- a/src/EfficientDynamoDb/Json/DocumentJsonSerializer.WriteAttributeValue.cs
+++ b/src/EfficientDynamoDb/Json/DocumentJsonSerializer.WriteAttributeValue.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Text;
+using System.Text.Json;
+using EfficientDynamoDb.DocumentModel;
+using EfficientDynamoDb.Internal.Core;
+
+namespace EfficientDynamoDb.Json
+{
+    public static partial class DocumentJsonSerializer
+    {
+        private static void WriteAttributeValue(PooledByteBufferWriter buffer, Utf8JsonWriter writer, in AttributeValue attributeValue)
+        {
+            switch (attributeValue.Type)
+            {
+                case AttributeType.String:
+                    writer.WriteStringValue(attributeValue.AsString());
+                    break;
+                case AttributeType.Number:
+                    // Write null, then delete
+                    writer.WriteNullValue();
+                    writer.Flush();
+                    buffer.Advance(-NullUtf8BytesCount);
+
+                    var numberValue = attributeValue.AsNumberAttribute().Value;
+                    var bytesSize = Encoding.UTF8.GetByteCount(numberValue);
+
+                    var bytesWritten = Encoding.UTF8.GetBytes(numberValue, buffer.GetSpan(bytesSize));
+                    buffer.Advance(bytesWritten);
+                    break;
+                case AttributeType.Bool:
+                    writer.WriteBooleanValue(attributeValue.AsBool());
+                    break;
+                case AttributeType.Map:
+                    writer.WriteStartObject();
+
+                    foreach (var (key, value) in attributeValue.AsMapAttribute().Value)
+                    {
+                        writer.WritePropertyName(key);
+                        WriteAttributeValue(buffer, writer, value);
+                    }
+
+                    writer.WriteEndObject();
+                    break;
+                case AttributeType.List:
+                    writer.WriteStartArray();
+                    foreach (var item in attributeValue.AsListAttribute().Items)
+                        WriteAttributeValue(buffer, writer, in item);
+                    writer.WriteEndArray();
+                    break;
+                case AttributeType.StringSet:
+                    writer.WriteStartArray();
+                    foreach (var item in attributeValue.AsStringSetAttribute().Items)
+                        writer.WriteStringValue(item);
+                    writer.WriteEndArray();
+                    break;
+                case AttributeType.NumberSet:
+                    writer.WriteStartArray();
+
+                    if (writer.BytesPending > 0)
+                        writer.Flush();
+
+                    var isFirst = true;
+                    foreach (var item in attributeValue.AsNumberSetAttribute().Items)
+                    {
+                        if (!isFirst)
+                        {
+                            buffer.GetSpan(1)[0] = CommaUtf8Byte;
+                            buffer.Advance(1);
+                        }
+
+                        var byteCount = Encoding.UTF8.GetByteCount(item);
+                        buffer.Advance(Encoding.UTF8.GetBytes(item, buffer.GetSpan(byteCount)));
+                        isFirst = false;
+                    }
+
+                    writer.WriteEndArray();
+                    break;
+                case AttributeType.Null:
+                    writer.WriteNullValue();
+                    break;
+                case AttributeType.Binary:
+                    writer.WriteBase64StringValue(attributeValue.AsBinaryAttribute().Value);
+                    break;
+                case AttributeType.BinarySet:
+                    writer.WriteStartArray();
+                    foreach (var item in attributeValue.AsBinarySetAttribute().Items)
+                        writer.WriteBase64StringValue(item);
+                    writer.WriteEndArray();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException($"AttributeType '{attributeValue.Type}' is not supported.");
+            }
+        }
+    }
+}

--- a/src/EfficientDynamoDb/Json/DocumentJsonSerializer.cs
+++ b/src/EfficientDynamoDb/Json/DocumentJsonSerializer.cs
@@ -1,0 +1,113 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using EfficientDynamoDb.DocumentModel;
+using EfficientDynamoDb.Internal.Core;
+
+namespace EfficientDynamoDb.Json
+{
+    public static partial class DocumentJsonSerializer
+    {
+        private const int NullUtf8BytesCount = 4;
+        private static readonly byte CommaUtf8Byte = Encoding.UTF8.GetBytes(",")[0];
+        
+        public static string Serialize(Document document)
+        {
+            using var buffer = new PooledByteBufferWriter();
+            using var writer = new Utf8JsonWriter(buffer);
+            
+            WriteDocument(buffer, writer, document);
+
+            writer.Flush();
+
+            return Encoding.UTF8.GetString(buffer.WrittenMemory.Span);
+        }
+
+        public static string Serialize(IEnumerable<Document> documents)
+        {
+            using var buffer = new PooledByteBufferWriter();
+            using var writer = new Utf8JsonWriter(buffer);
+
+            writer.WriteStartArray();
+            
+            foreach (var document in documents)
+                WriteDocument(buffer, writer, document);
+            
+            writer.WriteEndArray();
+
+            writer.Flush();
+
+            return Encoding.UTF8.GetString(buffer.WrittenMemory.Span);
+        }
+
+        public static async Task SerializeAsync(Stream stream, Document document, CancellationToken cancellationToken = default)
+        {
+            using var buffer = new PooledByteBufferWriter(stream);
+            // ReSharper disable once UseAwaitUsing
+            using var writer = new Utf8JsonWriter(buffer);
+
+            writer.WriteStartObject();
+
+            foreach (var (key, attributeValue) in document)
+            {
+                writer.WritePropertyName(key);
+
+                WriteAttributeValue(buffer, writer, in attributeValue);
+
+                if (buffer.ShouldFlush(writer))
+                    await buffer.FlushAsync(writer, cancellationToken).ConfigureAwait(false);
+            }
+            
+            writer.WriteEndObject();
+            
+            await buffer.FlushAsync(writer, cancellationToken).ConfigureAwait(false);
+        }
+        
+        public static async Task SerializeAsync(Stream stream, IEnumerable<Document> documents, CancellationToken cancellationToken = default)
+        {
+            using var buffer = new PooledByteBufferWriter(stream);
+            // ReSharper disable once UseAwaitUsing
+            using var writer = new Utf8JsonWriter(buffer);
+
+            writer.WriteStartArray();
+
+            foreach (var document in documents)
+            {
+                writer.WriteStartObject();
+
+                foreach (var (key, attributeValue) in document)
+                {
+                    writer.WritePropertyName(key);
+
+                    WriteAttributeValue(buffer, writer, in attributeValue);
+
+                    if (buffer.ShouldFlush(writer))
+                        await buffer.FlushAsync(writer, cancellationToken).ConfigureAwait(false);
+                }
+
+                writer.WriteEndObject();
+            }
+
+            writer.WriteEndArray();
+            
+            await buffer.FlushAsync(writer, cancellationToken).ConfigureAwait(false);
+        }
+        
+        private static void WriteDocument(PooledByteBufferWriter buffer, Utf8JsonWriter writer, Document document)
+        {
+            writer.WriteStartObject();
+
+            foreach (var (key, attributeValue) in document)
+            {
+                writer.WritePropertyName(key);
+
+                WriteAttributeValue(buffer, writer, in attributeValue);
+            }
+
+            writer.WriteEndObject();
+        }
+    }
+}

--- a/src/EfficientDynamoDb/Json/Internal/DocumentArrayJsonRootConverter.cs
+++ b/src/EfficientDynamoDb/Json/Internal/DocumentArrayJsonRootConverter.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using EfficientDynamoDb.Converters;
+using EfficientDynamoDb.DocumentModel;
+using EfficientDynamoDb.Internal.Converters;
+using EfficientDynamoDb.Internal.Core;
+
+namespace EfficientDynamoDb.Json
+{
+    public class DocumentArrayJsonRootConverter : DdbConverter<IReadOnlyList<Document>>, IRootDdbConverter<IReadOnlyList<Document>>
+    {
+        public DocumentArrayJsonRootConverter() : base(true)
+        {
+        }
+
+        public bool TryReadRoot(ref DdbReader reader, out IReadOnlyList<Document> value)
+        {
+            var success = false;
+            reader.State.PushDocument();
+
+            try
+            {
+                ref var current = ref reader.State.GetCurrent();
+
+                if (DocumentJsonReader.TryReadBuffer(ref reader, ref current))
+                {
+                    value = CreateDocumentsArray(current.AttributesBuffer);
+                    return success = true;
+                }
+            
+                Unsafe.SkipInit(out value);
+                return success = false;
+            }
+            finally
+            {
+                reader.State.Pop(success);
+            }
+        }
+
+        public override IReadOnlyList<Document> Read(in AttributeValue attributeValue) => throw new NotSupportedException();
+
+        public override AttributeValue Write(ref IReadOnlyList<Document> value) => throw new NotSupportedException();
+
+        private static Document[] CreateDocumentsArray(ReusableBuffer<AttributeValue> buffer)
+        {
+            var array = new Document[buffer.Index];
+
+            for (var i = 0; i < buffer.Index; i++)
+                array[i] = buffer.RentedBuffer![i]._mapValue.Value;
+
+            return array;
+        }
+    }
+}

--- a/src/EfficientDynamoDb/Json/Internal/DocumentDdbReader.TryReadList.cs
+++ b/src/EfficientDynamoDb/Json/Internal/DocumentDdbReader.TryReadList.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using EfficientDynamoDb.Converters;
+using EfficientDynamoDb.DocumentModel;
+using EfficientDynamoDb.Internal.Core;
+using EfficientDynamoDb.Internal.Extensions;
+using EfficientDynamoDb.Internal.Reader;
+
+namespace EfficientDynamoDb.Json
+{
+    internal static partial class DocumentJsonReader
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryReadList(ref DdbReader reader, ref DdbEntityReadStackFrame frame)
+        {
+            if (!TryReadList(ref reader, out var value))
+                return false;
+            
+            frame.AttributesBuffer.Add(new AttributeValue(new ListAttributeValue(value)));
+            return true;
+        }
+        
+        private static bool TryReadList(ref DdbReader reader, out List<AttributeValue> value)
+        {
+            var success = false;
+            reader.State.PushDocument();
+
+            try
+            {
+                ref var current = ref reader.State.GetCurrent();
+
+                // ReSharper disable once AssignmentInConditionalExpression
+                if (success = TryReadBuffer(ref reader, ref current))
+                    value = CreateListFromBuffer(ref current.AttributesBuffer);
+                else
+                    Unsafe.SkipInit(out value);
+
+                return success;
+            }
+            finally
+            {
+                reader.State.Pop(success);
+            }
+        }
+
+        public static bool TryReadBuffer(ref DdbReader reader, ref DdbEntityReadStackFrame current)
+        {
+            if (reader.State.UseFastPath)
+            {
+                while (true)
+                {
+                    // Value or end array
+                    reader.JsonReaderValue.ReadWithVerify();
+
+                    if (reader.JsonReaderValue.TokenType == JsonTokenType.EndArray)
+                        break;
+
+                    TryReadValue(ref reader, ref current);
+                }
+
+                return true;
+            }
+            else
+            {
+
+                if (current.PropertyState != DdbStackFramePropertyState.None)
+                {
+                    if (current.PropertyState < DdbStackFramePropertyState.ReadValue)
+                    {
+                        if (!reader.JsonReaderValue.Read())
+                            return false;
+
+                        current.PropertyState = DdbStackFramePropertyState.ReadValue;
+                    }
+
+                    if (current.PropertyState < DdbStackFramePropertyState.TryRead)
+                    {
+                        if (!TryReadValue(ref reader, ref current))
+                            return false;
+                    }
+
+                    current.PropertyState = DdbStackFramePropertyState.None;
+                }
+
+                while (true)
+                {
+                    if (!reader.JsonReaderValue.Read())
+                        return false;
+
+                    current.PropertyState = DdbStackFramePropertyState.ReadValue;
+
+                    if (reader.JsonReaderValue.TokenType == JsonTokenType.EndArray)
+                        break;
+
+                    if (!TryReadValue(ref reader, ref current))
+                        return false;
+
+                    current.PropertyState = DdbStackFramePropertyState.None;
+                }
+
+
+                return true;
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static List<AttributeValue> CreateListFromBuffer(ref ReusableBuffer<AttributeValue> buffer)
+        {
+            var list = new List<AttributeValue>(buffer.Index);
+
+            for (var i = 0; i < buffer.Index; i++)
+                list.Add(buffer.RentedBuffer![i]);
+
+            return list;
+        }
+    }
+}

--- a/src/EfficientDynamoDb/Json/Internal/DocumentDdbReader.TryReadMap.cs
+++ b/src/EfficientDynamoDb/Json/Internal/DocumentDdbReader.TryReadMap.cs
@@ -1,0 +1,127 @@
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using EfficientDynamoDb.Converters;
+using EfficientDynamoDb.DocumentModel;
+using EfficientDynamoDb.Internal.Extensions;
+using EfficientDynamoDb.Internal.Reader;
+using EfficientDynamoDb.Internal.Reader.DocumentDdbReader;
+
+namespace EfficientDynamoDb.Json
+{
+    internal static partial class DocumentJsonReader
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryReadMap(ref DdbReader reader, ref DdbEntityReadStackFrame frame)
+        {
+            if (!TryReadMap(ref reader, out var document))
+                return false;
+            
+            frame.AttributesBuffer.Add(document);
+            return true;
+        }
+        
+        public static bool TryReadMap(ref DdbReader reader, out Document value)
+        {
+            var success = false;
+
+            reader.State.PushDocument();
+            try
+            {
+                ref var current = ref reader.State.GetCurrent();
+
+                if (reader.State.UseFastPath)
+                {
+                    while (true)
+                    {
+                        // Property name
+                        reader.JsonReaderValue.ReadWithVerify();
+
+                        if (reader.JsonReaderValue.TokenType == JsonTokenType.EndObject)
+                            break;
+
+                        current.StringBuffer.Add(GetCachedString(ref reader.JsonReaderValue, ref reader.State));
+                        
+                        // Attribute value
+                        reader.JsonReaderValue.ReadWithVerify();
+
+                        TryReadValue(ref reader, ref current);
+                    }
+
+                    value = DocumentJsonReader.CreateDocumentFromBuffer(ref current)!;
+
+                    return success = true;
+                }
+                else
+                {
+                    Unsafe.SkipInit(out value);
+                    
+                    if (current.PropertyState != DdbStackFramePropertyState.None)
+                    {
+                        if (current.PropertyState < DdbStackFramePropertyState.Name)
+                        {
+                            current.StringBuffer.Add(GetCachedString(ref reader.JsonReaderValue, ref reader.State));
+                            current.PropertyState = DdbStackFramePropertyState.Name;
+                        }
+
+                        if (current.PropertyState < DdbStackFramePropertyState.ReadValue)
+                        {
+                            if (!reader.JsonReaderValue.Read())
+                                return success = false;
+
+                            current.PropertyState = DdbStackFramePropertyState.ReadValue;
+                        }
+
+                        if (current.PropertyState < DdbStackFramePropertyState.TryRead)
+                        {
+                            if (!TryReadValue(ref reader, ref current))
+                                return success = false;
+                        }
+
+                        current.PropertyState = DdbStackFramePropertyState.None;
+                    }
+
+                    while (true)
+                    {
+                        // Property name
+                        if (!reader.JsonReaderValue.Read())
+                            return success = false;
+
+                        if (reader.JsonReaderValue.TokenType == JsonTokenType.EndObject)
+                            break;
+
+                        current.StringBuffer.Add(GetCachedString(ref reader.JsonReaderValue, ref reader.State));
+                        current.PropertyState = DdbStackFramePropertyState.Name;
+
+                        if (!reader.JsonReaderValue.Read())
+                            return success = false;
+
+                        current.PropertyState = DdbStackFramePropertyState.ReadValue;
+
+                        if (!TryReadValue(ref reader, ref current))
+                            return success = false;
+                        
+                        current.PropertyState = DdbStackFramePropertyState.None;
+                    }
+
+                    value = DocumentJsonReader.CreateDocumentFromBuffer(ref current);
+                    return success = true;
+                }
+            }
+            finally
+            {
+                reader.State.Pop(success);
+            }
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Document CreateDocumentFromBuffer(ref DdbEntityReadStackFrame frame)
+        {
+            var document = new Document(frame.StringBuffer.Index);
+            
+            for (var i = 0; i < frame.StringBuffer.Index; i++)
+                document.Add(frame.StringBuffer.RentedBuffer![i], frame.AttributesBuffer.RentedBuffer![i]);
+
+            return document;
+        }
+    }
+}

--- a/src/EfficientDynamoDb/Json/Internal/DocumentJsonReader.cs
+++ b/src/EfficientDynamoDb/Json/Internal/DocumentJsonReader.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Text.Json;
+using EfficientDynamoDb.Converters;
+using EfficientDynamoDb.DocumentModel;
+using EfficientDynamoDb.Exceptions;
+using EfficientDynamoDb.Internal.Reader;
+
+namespace EfficientDynamoDb.Json
+{
+    internal partial class DocumentJsonReader
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryReadValue(ref DdbReader reader, ref DdbEntityReadStackFrame frame)
+        {
+            return reader.JsonReaderValue.TokenType switch
+            {
+                JsonTokenType.String => TryReadString(ref reader, ref frame),
+                JsonTokenType.Number => TryReadNumber(ref reader, ref frame),
+                JsonTokenType.True => TryReadTrue(ref reader, ref frame),
+                JsonTokenType.False => TryReadFalse(ref reader, ref frame),
+                JsonTokenType.StartObject => TryReadMap(ref reader, ref frame),
+                JsonTokenType.StartArray => TryReadList(ref reader, ref frame),
+                JsonTokenType.Null => TryReadNull(ref reader, ref frame),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryReadString(ref DdbReader reader, ref DdbEntityReadStackFrame frame)
+        {
+            frame.AttributesBuffer.Add(new AttributeValue(new StringAttributeValue(reader.JsonReaderValue.GetString()!)));
+            return true;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryReadNumber(ref DdbReader reader, ref DdbEntityReadStackFrame frame)
+        {
+            frame.AttributesBuffer.Add(new AttributeValue(new NumberAttributeValue(Encoding.UTF8.GetString(reader.JsonReaderValue.ValueSpan))));
+            return true;
+        }
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryReadTrue(ref DdbReader reader, ref DdbEntityReadStackFrame frame)
+        {
+            frame.AttributesBuffer.Add(new AttributeValue(new BoolAttributeValue(true)));
+            return true;
+        }
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryReadFalse(ref DdbReader reader, ref DdbEntityReadStackFrame frame)
+        {
+            frame.AttributesBuffer.Add(new AttributeValue(new BoolAttributeValue(false)));
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool TryReadNull(ref DdbReader reader, ref DdbEntityReadStackFrame frame)
+        {
+            frame.AttributesBuffer.Add(new AttributeValue(new NullAttributeValue(true)));
+            return true;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string GetCachedString(ref Utf8JsonReader reader, ref DdbEntityReadStack state)
+        {
+            return !state.KeysCache.IsInitialized || !state.KeysCache.TryGetOrAdd(ref reader, out var value)
+                ? reader.GetString()!
+                : value!;
+        }
+    }
+}

--- a/src/EfficientDynamoDb/Json/Internal/DocumentJsonRootConverter.cs
+++ b/src/EfficientDynamoDb/Json/Internal/DocumentJsonRootConverter.cs
@@ -1,0 +1,20 @@
+using System;
+using EfficientDynamoDb.Converters;
+using EfficientDynamoDb.DocumentModel;
+using EfficientDynamoDb.Internal.Converters;
+
+namespace EfficientDynamoDb.Json
+{
+    internal sealed class DocumentJsonRootConverter : DdbConverter<Document>, IRootDdbConverter<Document>
+    {
+        public DocumentJsonRootConverter() : base(true)
+        {
+        }
+
+        public bool TryReadRoot(ref DdbReader reader, out Document value) => DocumentJsonReader.TryReadMap(ref reader, out value);
+
+        public override Document Read(in AttributeValue attributeValue) => throw new NotSupportedException();
+
+        public override AttributeValue Write(ref Document value) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
Initial `Document` to simple JSON serialization that addresses #109 

The original idea of just shipping the custom JSON converter doesn't work because `System.Text.Json` doesn't support sterilizing strings as numbers or just serializing raw JSON. In order to write raw JSON, we have to take control over the JSON buffer, so in the end, we provide our own `DocumentJsonSerializer.Serialize` / `DocumentJsonSerializer.Deserialize` methods. It has some benefits like reusing our existing JSON serialization code with some optimizations like buffering properties / array items and interning attribute names. From the disadvantages side, it means that a `Document` object can't be serialized using `System.Text.Json.JsonSerializer`, but SDK lacks it as well.

Currently, serialization is implemented to mimic the SDK behavior. The problem is that this whole idea of serializing to simple JSON without saving attribute types has some flaws:
* Sets are serialized as lists - after deserialization all sets become lists.
* Binary data is serialized as base64 encoded strings - after deserialization all binary data become strings.

My personal opinion is that I would probably prefer to serialize DTOs instead of plain document objects. But the fact that this feature exists in SDK means that we need to support it in some way. I am unsure if `DocumentJsonSerializer` is a good name because maybe in the future we can decide to provide our own serialization logic, I am wondering if we should rename it to something like `SdkDocumentJsonSerializer`.