### PR TITLE
aws credentials from EnvironmentVariable

### DIFF
--- a/EfficientDynamoDb.Tests/Config/AwsCredentialsTests.cs
+++ b/EfficientDynamoDb.Tests/Config/AwsCredentialsTests.cs
@@ -82,8 +82,3 @@ namespace EfficientDynamoDb.Tests.Config.Retries
     }
 
 }
-
-    
-
-
-}

--- a/EfficientDynamoDb.Tests/Config/AwsCredentialsTests.cs
+++ b/EfficientDynamoDb.Tests/Config/AwsCredentialsTests.cs
@@ -12,15 +12,30 @@ namespace EfficientDynamoDb.Tests.Config.Retries
     [TestFixture]
     public class AwsCredentialsTests
     {
+        [SetUp]
+        public void ClearEnvironmentVariables()
+        {
+            var keys = new[]
+             {
+                    "AWS_ACCESS_KEY_ID",
+                    "AWS_SECRET_ACCESS_KEY",
+                    "AWS_SESSION_TOKEN",
+                };
+            foreach (var key in keys)
+            {
+                Environment.SetEnvironmentVariable(key, null, EnvironmentVariableTarget.Process);
+            }
+
+        }
 
         [Test]
         public void GetFromEnvironmentTest()
         {
             var keys = new[]
              {
-                "AWS_ACCESS_KEY_ID",
-                "AWS_SECRET_ACCESS_KEY"
-            };
+                    "AWS_ACCESS_KEY_ID",
+                    "AWS_SECRET_ACCESS_KEY"
+                };
             foreach (var key in keys)
             {
                 Environment.SetEnvironmentVariable(key, "TEST###" + key, EnvironmentVariableTarget.Process);
@@ -29,20 +44,21 @@ namespace EfficientDynamoDb.Tests.Config.Retries
             var result = AwsCredentials.GetAwsCredentials();
 
             Assert.NotNull(result);
-            Assert.Equals(keys[0], result.AccessKey);
-            Assert.Equals(keys[1], result.SecretKey);
-            Assert.IsNull(result.Token);
+            Assert.Equals("TEST###" + keys[0], result.AccessKey);
+            Assert.Equals("TEST###" + keys[1], result.SecretKey);
+            Assert.Null(result.Token);
         }
+
 
         [Test]
         public void GetFromEnvironmentTestWithToken()
         {
             var keys = new[]
              {
-                "AWS_ACCESS_KEY_ID",
-                "AWS_SECRET_ACCESS_KEY",
-                "AWS_SESSION_TOKEN",
-            };
+                    "AWS_ACCESS_KEY_ID",
+                    "AWS_SECRET_ACCESS_KEY",
+                    "AWS_SESSION_TOKEN",
+                };
             foreach (var key in keys)
             {
                 Environment.SetEnvironmentVariable(key, "TEST###" + key, EnvironmentVariableTarget.Process);
@@ -51,21 +67,21 @@ namespace EfficientDynamoDb.Tests.Config.Retries
             var result = AwsCredentials.GetAwsCredentials();
 
             Assert.NotNull(result);
-            Assert.Equals(keys[0], result.AccessKey);
-            Assert.Equals(keys[1], result.SecretKey);
-            Assert.Equals(keys[2], result.Token);
+            Assert.Equals("TEST###" + keys[0], result.AccessKey);
+            Assert.Equals("TEST###" + keys[1], result.SecretKey);
+            Assert.Equals("TEST###" + keys[2], result.Token);
         }
-
-
 
         [Test]
         public void GetNullFromEnvironment()
         {
-            Assert.IsNull(AwsCredentials.GetAwsCredentials());
+            Assert.Null(AwsCredentials.GetAwsCredentials());
             var result = AwsCredentials.GetAwsCredentials();
         }
 
     }
+
+}
 
     
 

--- a/EfficientDynamoDb.Tests/Config/AwsCredentialsTests.cs
+++ b/EfficientDynamoDb.Tests/Config/AwsCredentialsTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using EfficientDynamoDb.Configs;
+using EfficientDynamoDb.Configs.Retries;
+using EfficientDynamoDb.Internal.Core.Utilities;
+using NUnit.Framework;
+using Telerik.JustMock;
+using Telerik.JustMock.Helpers;
+
+namespace EfficientDynamoDb.Tests.Config.Retries
+{
+    [TestFixture]
+    public class AwsCredentialsTests
+    {
+
+        [Test]
+        public void GetFromEnvironmentTest()
+        {
+            var keys = new[]
+             {
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY"
+            };
+            foreach (var key in keys)
+            {
+                Environment.SetEnvironmentVariable(key, "TEST###" + key, EnvironmentVariableTarget.Process);
+            }
+
+            var result = AwsCredentials.GetAwsCredentials();
+
+            Assert.NotNull(result);
+            Assert.Equals(keys[0], result.AccessKey);
+            Assert.Equals(keys[1], result.SecretKey);
+            Assert.IsNull(result.Token);
+        }
+
+        [Test]
+        public void GetFromEnvironmentTestWithToken()
+        {
+            var keys = new[]
+             {
+                "AWS_ACCESS_KEY_ID",
+                "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN",
+            };
+            foreach (var key in keys)
+            {
+                Environment.SetEnvironmentVariable(key, "TEST###" + key, EnvironmentVariableTarget.Process);
+            }
+
+            var result = AwsCredentials.GetAwsCredentials();
+
+            Assert.NotNull(result);
+            Assert.Equals(keys[0], result.AccessKey);
+            Assert.Equals(keys[1], result.SecretKey);
+            Assert.Equals(keys[2], result.Token);
+        }
+
+
+
+        [Test]
+        public void GetNullFromEnvironment()
+        {
+            Assert.IsNull(AwsCredentials.GetAwsCredentials());
+            var result = AwsCredentials.GetAwsCredentials();
+        }
+
+    }
+
+    
+
+
+}

--- a/src/EfficientDynamoDb/Configs/AwsCredentials.cs
+++ b/src/EfficientDynamoDb/Configs/AwsCredentials.cs
@@ -24,7 +24,21 @@ namespace EfficientDynamoDb.Configs
             SecretKey = secretKey;
             Token = token;
         }
-        
+
+        public static AwsCredentials? GetAwsCredentials()
+        {
+            var awsAccessKeyId = Environment.GetEnvironmentVariable("AWS_ACCESS_KEY_ID");
+            var awsSecretAccessKey = Environment.GetEnvironmentVariable("AWS_SECRET_ACCESS_KEY");
+            var awsSessionToken = Environment.GetEnvironmentVariable("AWS_SESSION_TOKEN");
+
+            if (string.IsNullOrEmpty(awsAccessKeyId) && string.IsNullOrEmpty(awsSecretAccessKey))
+            {
+                return default;
+            }
+
+            return new AwsCredentials(awsAccessKeyId!, awsSecretAccessKey!, awsSessionToken);
+        }
+
         public ValueTask<AwsCredentials> GetCredentialsAsync(CancellationToken cancellationToken = default) => new ValueTask<AwsCredentials>(this);
 
         public bool Equals(AwsCredentials? other)


### PR DESCRIPTION
It is a function to acquire aws rights that are automatically assigned to aws lambda and ecs.
Official awsdk acquires it in various situations through Fallback Credentials Factory.Get Credentials(), but in this case, we implemented only the most basic functions first because we only need to obtain the authority to connect to dynamodb.

It corresponds to No. 5 and No. 6 of the document below.
https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/creds-assign.html