### PR TITLE
Change doc about transact operations count limit

### DIFF
--- a/src/EfficientDynamoDb/Operations/TransactGetItems/TransactGetItemsRequest.cs
+++ b/src/EfficientDynamoDb/Operations/TransactGetItems/TransactGetItemsRequest.cs
@@ -12,7 +12,7 @@ namespace EfficientDynamoDb.Operations.TransactGetItems
         public ReturnConsumedCapacity ReturnConsumedCapacity { get; set; }
         
         /// <summary>
-        /// An ordered array of up to 25 <see cref="GetRequest"/> objects.
+        /// An ordered array of up to 100 <see cref="GetRequest"/> objects.
         /// </summary>
         public IReadOnlyCollection<TransactGetRequest> TransactItems { get; set; } = ArraySegment<TransactGetRequest>.Empty;
     }

--- a/src/EfficientDynamoDb/Operations/TransactWriteItems/TransactWriteItemsRequest.cs
+++ b/src/EfficientDynamoDb/Operations/TransactWriteItems/TransactWriteItemsRequest.cs
@@ -8,7 +8,7 @@ namespace EfficientDynamoDb.Operations.TransactWriteItems
     public class TransactWriteItemsRequest
     {
         /// <summary>
-        /// An ordered array of up to 25 <see cref="TransactWriteItem"/> objects, each of which contains a <see cref="ConditionCheck"/>, <see cref="TransactPutItem"/>, <see cref="TransactUpdateItem"/>, or <see cref="TransactDeleteItem"/> object. These can operate on items in different tables, but the tables must reside in the same AWS account and Region, and no two of them can operate on the same item.
+        /// An ordered array of up to 100 <see cref="TransactWriteItem"/> objects, each of which contains a <see cref="ConditionCheck"/>, <see cref="TransactPutItem"/>, <see cref="TransactUpdateItem"/>, or <see cref="TransactDeleteItem"/> object. These can operate on items in different tables, but the tables must reside in the same AWS account and Region, and no two of them can operate on the same item.
         /// </summary>
         public IReadOnlyCollection<TransactWriteItem> TransactItems { get; set; } = Array.Empty<TransactWriteItem>();
         


### PR DESCRIPTION
DynamoDB now supports up to 100 operations in a single transaction
