### PR TITLE
Shrink the ReadOnlySpan passed to the CryptoService

### DIFF
--- a/src/EfficientDynamoDb/Internal/Signing/AwsRequestSigner.cs
+++ b/src/EfficientDynamoDb/Internal/Signing/AwsRequestSigner.cs
@@ -53,7 +53,7 @@ namespace EfficientDynamoDb.Internal.Signing
 
             var data = sequence.IsSingleSegment ? sequence.First : stream.GetBuffer();
 
-            CryptoService.ComputeSha256Hash(data.Span, hash, out _);
+            CryptoService.ComputeSha256Hash(data.Span.Slice(0, (int)sequence.Length), hash, out _);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Microsoft.IO.RecyclableMemoryStream uses an exponental growth algo that causes a specific stream, when converted to a buffer, to contain a lot of extra null bytes at the end of it.  This, in turn, causes the Sha256 to be different, causing request failures due to mismatching signatures.

Fixes #203