### PR TITLE
Expose API for returning original item on conditional failure

### DIFF
--- a/src/EfficientDynamoDb/Exceptions/ConditionalCheckFailedException.cs
+++ b/src/EfficientDynamoDb/Exceptions/ConditionalCheckFailedException.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Runtime.Serialization;
+using EfficientDynamoDb.DocumentModel;
+using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Exceptions
 {
@@ -9,14 +11,28 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class ConditionalCheckFailedException : DdbException
     {
+        public Document? Item { get; }
+        
         public ConditionalCheckFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
 
+        public ConditionalCheckFailedException(Document? item, string message) : base(message)
+        {
+            Item = item;
+        }
+        
+        public ConditionalCheckFailedException(Document? item, string message, Exception innerException) : base(message, innerException)
+        {
+            Item = item;
+        }
+        
+        [Obsolete("This constructor is obsolete and will be removed in next major version. Use constructor with `Document? item` parameter instead.")]
         public ConditionalCheckFailedException(string message) : base(message)
         {
         }
 
+        [Obsolete("This constructor is obsolete and will be removed in next major version. Use constructor with `Document? item` parameter instead.")]
         public ConditionalCheckFailedException(string message, Exception innerException) : base(message, innerException)
         {
         }

--- a/src/EfficientDynamoDb/Internal/ErrorHandler.cs
+++ b/src/EfficientDynamoDb/Internal/ErrorHandler.cs
@@ -40,6 +40,7 @@ namespace EfficientDynamoDb.Internal
                     switch (response.StatusCode)
                     {
                         case HttpStatusCode.BadRequest:
+                            // TODO: Use Span for `type` to avoid redundant allocation due to Substring call below.
                             var type = error.Type;
                             var exceptionStart = error.Type?.LastIndexOf('#') ?? -1;
                             if (exceptionStart != -1)
@@ -52,12 +53,22 @@ namespace EfficientDynamoDb.Internal
                                     .ReadAsync<TransactionCancelledResponse>(recyclableStream, classInfo, metadata, false, cancellationToken: cancellationToken)
                                     .ConfigureAwait(false);
                                 throw new TransactionCanceledException(transactionCancelledResponse.Value!.CancellationReasons, error.Message);
-                            }
+                            } 
                             
+                            if (type == "ConditionalCheckFailedException")
+                            {
+                                var classInfo = metadata.GetOrAddClassInfo(typeof(ConditionalCheckFailedResponse),
+                                    typeof(JsonObjectDdbConverter<ConditionalCheckFailedResponse>));
+                                var conditionalCheckFailedResponse = await EntityDdbJsonReader
+                                    .ReadAsync<ConditionalCheckFailedResponse>(recyclableStream, classInfo, metadata, false,
+                                        cancellationToken: cancellationToken)
+                                    .ConfigureAwait(false);
+                                throw new ConditionalCheckFailedException(conditionalCheckFailedResponse.Value!.Item, error.Message);
+                            }
+
                             throw type switch
                             {
                                 "AccessDeniedException" => new AccessDeniedException(error.Message),
-                                "ConditionalCheckFailedException" => new ConditionalCheckFailedException(error.Message),
                                 "IncompleteSignatureException" => new IncompleteSignatureException(error.Message),
                                 "ItemCollectionSizeLimitExceededException" => new ItemCollectionSizeLimitExceededException(error.Message),
                                 "LimitExceededException" => new LimitExceededException(error.Message),

--- a/src/EfficientDynamoDb/Internal/ErrorHandler.cs
+++ b/src/EfficientDynamoDb/Internal/ErrorHandler.cs
@@ -28,7 +28,6 @@ namespace EfficientDynamoDb.Internal
                     throw new ServiceUnavailableException("DynamoDB is currently unavailable. (This should be a temporary state.)");
 
                 var recyclableStream = DynamoDbHttpContent.MemoryStreamManager.GetStream();
-
                 try
                 {
                     await responseStream.CopyToAsync(recyclableStream, cancellationToken).ConfigureAwait(false);
@@ -53,16 +52,14 @@ namespace EfficientDynamoDb.Internal
                                     .ReadAsync<TransactionCancelledResponse>(recyclableStream, classInfo, metadata, false, cancellationToken: cancellationToken)
                                     .ConfigureAwait(false);
                                 throw new TransactionCanceledException(transactionCancelledResponse.Value!.CancellationReasons, error.Message);
-                            } 
+                            }
                             
                             if (type == "ConditionalCheckFailedException")
                             {
-                                var classInfo = metadata.GetOrAddClassInfo(typeof(ConditionalCheckFailedResponse),
+                                var classInfo = metadata.GetOrAddClassInfo(typeof(ConditionalCheckFailedResponse), 
                                     typeof(JsonObjectDdbConverter<ConditionalCheckFailedResponse>));
-                                var conditionalCheckFailedResponse = await EntityDdbJsonReader
-                                    .ReadAsync<ConditionalCheckFailedResponse>(recyclableStream, classInfo, metadata, false,
-                                        cancellationToken: cancellationToken)
-                                    .ConfigureAwait(false);
+                                var conditionalCheckFailedResponse = await EntityDdbJsonReader.ReadAsync<ConditionalCheckFailedResponse>(recyclableStream, 
+                                        classInfo, metadata, false, cancellationToken: cancellationToken).ConfigureAwait(false);
                                 throw new ConditionalCheckFailedException(conditionalCheckFailedResponse.Value!.Item, error.Message);
                             }
 

--- a/src/EfficientDynamoDb/Operations/DeleteItem/DeleteItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/DeleteItem/DeleteItemRequestBuilder.cs
@@ -63,6 +63,9 @@ namespace EfficientDynamoDb.Operations.DeleteItem
         public IDeleteItemEntityRequestBuilder<TEntity> WithReturnValues(ReturnValues returnValues) =>
             new DeleteItemEntityRequestBuilder<TEntity>(_context, new ReturnValuesNode(returnValues, _node));
 
+        public IDeleteItemEntityRequestBuilder<TEntity> WithReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure option) =>
+            new DeleteItemEntityRequestBuilder<TEntity>(_context, new ReturnValuesOnConditionCheckFailureNode(option, _node));
+
         public IDeleteItemEntityRequestBuilder<TEntity> WithReturnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity) =>
             new DeleteItemEntityRequestBuilder<TEntity>(_context, new ReturnConsumedCapacityNode(returnConsumedCapacity, _node));
 

--- a/src/EfficientDynamoDb/Operations/DeleteItem/IDeleteItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/DeleteItem/IDeleteItemRequestBuilder.cs
@@ -68,7 +68,14 @@ namespace EfficientDynamoDb.Operations.DeleteItem
         /// The only supported values for <c>DeleteItem</c> operation are <see cref="ReturnValues.None"/> and <see cref="ReturnValues.AllOld"/>.
         /// </remarks>
         IDeleteItemEntityRequestBuilder<TEntity> WithReturnValues(ReturnValues returnValues);
-        
+
+        /// <summary>
+        /// Specifies how to handle return values if the operation fails.
+        /// </summary>
+        /// <param name="option">Option for handling return values on condition check failure.</param>
+        /// <returns>DeleteItem operation builder.</returns>
+        IDeleteItemEntityRequestBuilder<TEntity> WithReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure option);
+
         /// <summary>
         /// Specifies the consumed capacity details to include in the response.
         /// </summary>

--- a/src/EfficientDynamoDb/Operations/PutItem/IPutItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/PutItem/IPutItemRequestBuilder.cs
@@ -66,6 +66,13 @@ namespace EfficientDynamoDb.Operations.PutItem
         /// The only supported values for <c>PutItem</c> operation are <see cref="ReturnValues.None"/> and <see cref="ReturnValues.AllOld"/>.
         /// </remarks>
         IPutItemEntityRequestBuilder<TEntity> WithReturnValues(ReturnValues returnValues);
+
+        /// <summary>
+        /// Specifies how to handle return values if the operation fails.
+        /// </summary>
+        /// <param name="option">Option for handling return values on condition check failure.</param>
+        /// <returns>PutItem operation builder.</returns>
+        IPutItemEntityRequestBuilder<TEntity> WithReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure option);
         
         /// <summary>
         /// Specifies the consumed capacity details to include in the response.

--- a/src/EfficientDynamoDb/Operations/PutItem/PutItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/PutItem/PutItemRequestBuilder.cs
@@ -71,6 +71,9 @@ namespace EfficientDynamoDb.Operations.PutItem
         
         public IPutItemEntityRequestBuilder<TEntity> WithReturnValues(ReturnValues returnValues) =>
             new PutItemEntityRequestBuilder<TEntity>(_context, new ReturnValuesNode(returnValues, _node));
+        
+        public IPutItemEntityRequestBuilder<TEntity> WithReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure option) =>
+            new PutItemEntityRequestBuilder<TEntity>(_context, new ReturnValuesOnConditionCheckFailureNode(option, _node));
 
         public IPutItemEntityRequestBuilder<TEntity> WithReturnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity) =>
             new PutItemEntityRequestBuilder<TEntity>(_context, new ReturnConsumedCapacityNode(returnConsumedCapacity, _node));

--- a/src/EfficientDynamoDb/Operations/Shared/ConditionalCheckFailedResponse.cs
+++ b/src/EfficientDynamoDb/Operations/Shared/ConditionalCheckFailedResponse.cs
@@ -1,0 +1,16 @@
+﻿using EfficientDynamoDb.Attributes;
+using EfficientDynamoDb.DocumentModel;
+using EfficientDynamoDb.Internal.Converters.Json;
+
+namespace EfficientDynamoDb.Operations.Shared
+{
+    [DynamoDbConverter(typeof(JsonObjectDdbConverter<ConditionalCheckFailedResponse>))]
+    public class ConditionalCheckFailedResponse
+    {
+        [DynamoDbProperty("Message")]
+        public string Message { get; set; } = null!;
+
+        [DynamoDbProperty("Item")]
+        public Document? Item { get; set; }
+    }
+}

--- a/src/EfficientDynamoDb/Operations/UpdateItem/IUpdateRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/UpdateItem/IUpdateRequestBuilder.cs
@@ -25,6 +25,13 @@ namespace EfficientDynamoDb.Operations.UpdateItem
         IUpdateEntityRequestBuilder<TEntity> WithReturnValues(ReturnValues returnValues);
         
         /// <summary>
+        /// Specifies how to handle return values if the operation fails.
+        /// </summary>
+        /// <param name="option">Option for handling return values on condition check failure.</param>
+        /// <returns>UpdateItem operation builder.</returns>
+        IUpdateEntityRequestBuilder<TEntity> WithReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure option);
+
+        /// <summary>
         /// Specifies the consumed capacity details to include in the response.
         /// </summary>
         /// <param name="returnConsumedCapacity">The <see cref="ReturnConsumedCapacity"/> option.</param>

--- a/src/EfficientDynamoDb/Operations/UpdateItem/UpdateRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/UpdateItem/UpdateRequestBuilder.cs
@@ -51,6 +51,9 @@ namespace EfficientDynamoDb.Operations.UpdateItem
         public IUpdateEntityRequestBuilder<TEntity> WithReturnValues(ReturnValues returnValues) =>
             new UpdateEntityRequestBuilder<TEntity>(_context, new ReturnValuesNode(returnValues, _node));
 
+        public IUpdateEntityRequestBuilder<TEntity> WithReturnValuesOnConditionCheckFailure(ReturnValuesOnConditionCheckFailure option) =>
+            new UpdateEntityRequestBuilder<TEntity>(_context, new ReturnValuesOnConditionCheckFailureNode(option, _node));
+
         public IUpdateEntityRequestBuilder<TEntity> WithReturnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity) =>
             new UpdateEntityRequestBuilder<TEntity>(_context, new ReturnConsumedCapacityNode(returnConsumedCapacity, _node));
 


### PR DESCRIPTION
This PR covers the DynamoDB update: https://aws.amazon.com/about-aws/whats-new/2023/06/amazon-dynamodb-cost-failed-conditional-writes/

Supported operations:
- PutItem
- UpdateItem
- DeleteItem

Item is returned as Document in ConditionalCheckFailedException.
