### PR TITLE
Implement UPPER_SNAKE_CASE enum converter for control plane API

### DIFF
--- a/EfficientDynamoDb.Tests/Internal/JsonConverters/DdbEnumJsonConverter.cs
+++ b/EfficientDynamoDb.Tests/Internal/JsonConverters/DdbEnumJsonConverter.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Text.Json;
+using EfficientDynamoDb.Internal.JsonConverters;
+using EfficientDynamoDb.Operations.DescribeTable.Models.Enums;
+using NUnit.Framework;
+
+namespace EfficientDynamoDb.Tests.Internal.JsonConverters
+{
+    [TestFixture]
+    public class DdbEnumJsonConverter
+    {
+        private readonly JsonSerializerOptions _options = new JsonSerializerOptions
+            { Converters = { new DdbEnumJsonConverterFactory() } };
+
+        [TestCase(KeyType.Hash, "HASH")]
+        [TestCase(SseType.Kms, "KMS")]
+        [TestCase(SseType.Aes256, "AES256")]
+        [TestCase(StreamViewType.NewAndOldImages, "NEW_AND_OLD_IMAGES")]
+        [TestCase(StreamViewType.KeysOnly, "KEYS_ONLY")]
+        public void EnumDeserializationTest<T>(T enumValue, string jsonValue) where T : struct, Enum
+        {
+            var json = $"\"{jsonValue}\"";
+
+            var result = JsonSerializer.Deserialize<T>(json, _options);
+
+            Assert.That(result, Is.EqualTo(enumValue));
+        }
+        
+        [TestCase(KeyType.Hash, "HASH")]
+        [TestCase(SseType.Kms, "KMS")]
+        [TestCase(SseType.Aes256, "AES256")]
+        [TestCase(StreamViewType.NewAndOldImages, "NEW_AND_OLD_IMAGES")]
+        [TestCase(StreamViewType.KeysOnly, "KEYS_ONLY")]
+        public void EnumSerializationTest<T>(T enumValue, string expectedJsonValue) where T : struct, Enum
+        {
+            var result = JsonSerializer.Serialize(enumValue, _options);
+            var expectedJson = $"\"{expectedJsonValue}\"";
+            
+            Assert.That(result, Is.EqualTo(expectedJson));
+        }
+    }
+}

--- a/src/Benchmarks/Benchmarks/Query/QueryBenchmarkBase.cs
+++ b/src/Benchmarks/Benchmarks/Query/QueryBenchmarkBase.cs
@@ -91,7 +91,7 @@ namespace Benchmarks.Query
             _describeTableBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new DescribeTableResponse(new TableDescription
             {
                 TableName = "production_" + Tables.TestTable,
-                KeySchema = new[] {new KeySchemaElement("pk", KeyType.HASH), new KeySchemaElement("sk", KeyType.RANGE)},
+                KeySchema = new[] {new KeySchemaElement("pk", KeyType.Hash), new KeySchemaElement("sk", KeyType.Range)},
                 AttributeDefinitions = new[] {new AttributeDefinition("pk", "S"), new AttributeDefinition("sk", "S")}
             }), new JsonSerializerOptions
             {

--- a/src/Benchmarks/Mocks/DescribeTableResponseFactory.cs
+++ b/src/Benchmarks/Mocks/DescribeTableResponseFactory.cs
@@ -15,7 +15,7 @@ namespace Benchmarks.Mocks
             return Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new DescribeTableResponse(new TableDescription
             {
                 TableName = "production_" + Tables.TestTable,
-                KeySchema = new[] {new KeySchemaElement("pk", EfficientDynamoDb.Operations.DescribeTable.Models.Enums.KeyType.HASH), new KeySchemaElement("sk", KeyType.RANGE)},
+                KeySchema = new[] {new KeySchemaElement("pk", EfficientDynamoDb.Operations.DescribeTable.Models.Enums.KeyType.Hash), new KeySchemaElement("sk", KeyType.Range)},
                 AttributeDefinitions = new[] {new AttributeDefinition("pk", "S"), new AttributeDefinition("sk", "S")}
             }), new JsonSerializerOptions
             {

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbLowLevelContext.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbLowLevelContext.cs
@@ -193,8 +193,8 @@ namespace EfficientDynamoDb
                     .ConfigureAwait(false);
 
                 var keySchema = response.Table.KeySchema;
-                return (keySchema.First(x => x.KeyType == KeyType.HASH).AttributeName,
-                    keySchema.FirstOrDefault(x => x.KeyType == KeyType.RANGE)?.AttributeName);
+                return (keySchema.First(x => x.KeyType == KeyType.Hash).AttributeName,
+                    keySchema.FirstOrDefault(x => x.KeyType == KeyType.Range)?.AttributeName);
             }
         }
 

--- a/src/EfficientDynamoDb/Internal/Extensions/DateTimeConverterExtensions.cs
+++ b/src/EfficientDynamoDb/Internal/Extensions/DateTimeConverterExtensions.cs
@@ -4,7 +4,7 @@ namespace EfficientDynamoDb.Internal.Extensions
 {
     internal static class DateTimeConverterExtensions
     {
-        public static long ToUnixSeconds(this DateTime dateTime) => (long) (dateTime - UnixEpochStart).TotalSeconds;
+        public static double ToUnixSeconds(this DateTime dateTime) => (dateTime - UnixEpochStart).TotalSeconds;
         
         public static DateTime FromUnixSeconds(this double seconds) => UnixEpochStart.AddSeconds(seconds);
 

--- a/src/EfficientDynamoDb/Internal/Extensions/StringNormalizationExtensions.cs
+++ b/src/EfficientDynamoDb/Internal/Extensions/StringNormalizationExtensions.cs
@@ -1,3 +1,5 @@
+using EfficientDynamoDb.Internal.Core;
+
 namespace EfficientDynamoDb.Internal.Extensions
 {
     internal static class StringNormalizationExtensions
@@ -38,6 +40,20 @@ namespace EfficientDynamoDb.Internal.Extensions
             }
 
             return new string(output, 0, currentIndex);
+        }
+
+        /// <summary>
+        /// Converts the string to UPPER_SNAKE_CASE and appends it to the <paramref name="builder"/>.
+        /// </summary>
+        public static void ToUpperSnakeCase(this string self, ref NoAllocStringBuilder builder)
+        {
+            for (var i = 0; i < self.Length; i++)
+            {
+                var c = self[i];
+                if (i != 0 && char.IsUpper(c))
+                    builder.Append("_");
+                builder.Append(char.ToUpperInvariant(c));
+            }
         }
     }
 }

--- a/src/EfficientDynamoDb/Internal/JsonConverters/DdbEnumJsonConverter.cs
+++ b/src/EfficientDynamoDb/Internal/JsonConverters/DdbEnumJsonConverter.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using EfficientDynamoDb.Internal.Core;
+using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.TypeParsers;
 
 namespace EfficientDynamoDb.Internal.JsonConverters
@@ -11,17 +13,21 @@ namespace EfficientDynamoDb.Internal.JsonConverters
         {
             var enumString = reader.GetString();
 
-            if (!EnumParser.TryParseCaseInsensitive(enumString, out T value))
-            {
-                return default;
-            }
-
-            return value;      
+            return EnumParser.TryParseUpperSnakeCase(enumString, out T value)
+                ? value
+                : default;
         }
 
         public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
         {
-            writer.WriteStringValue(value.ToString());
+            var enumString = value.ToString();
+            
+            Span<char> buffer = stackalloc char[enumString.Length * 2]; // Allocate enough space to account for new underscores
+            var sb = new NoAllocStringBuilder(in buffer, true);
+
+            enumString.ToUpperSnakeCase(ref sb);
+            
+            writer.WriteStringValue(sb.GetBuffer());
         }
     }
 }

--- a/src/EfficientDynamoDb/Internal/TypeParsers/EnumParser.cs
+++ b/src/EfficientDynamoDb/Internal/TypeParsers/EnumParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using EfficientDynamoDb.Internal.Core;
 
 namespace EfficientDynamoDb.Internal.TypeParsers
 {
@@ -8,5 +9,33 @@ namespace EfficientDynamoDb.Internal.TypeParsers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool TryParseCaseInsensitive<TEnum>(string? value, out TEnum result) where TEnum : struct, Enum =>
             Enum.TryParse(value, out result) || Enum.TryParse(value, true, out result);
+        
+        public static bool TryParseUpperSnakeCase<TEnum>(string? value, out TEnum result) where TEnum : struct, Enum
+        {
+            if (value == null)
+            {
+                result = default;
+                return false;
+            }
+
+            Span<char> buffer = stackalloc char[value.Length];
+            var sb = new NoAllocStringBuilder(in buffer, true);
+            
+            var isNextUpper = false;
+            foreach (var c in value)
+            {
+                if (c == '_')
+                {
+                    isNextUpper = true;
+                    continue;
+                }
+
+                var nextChar = isNextUpper ? c : char.ToLowerInvariant(c);
+                sb.Append(nextChar);
+                isNextUpper = false;
+            }
+            
+            return Enum.TryParse(sb.ToString(), true, out result);
+        }
     }
 }

--- a/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/BillingMode.cs
+++ b/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/BillingMode.cs
@@ -2,8 +2,8 @@ namespace EfficientDynamoDb.Operations.DescribeTable.Models.Enums
 {
     public enum BillingMode
     {
-        _UNKNOWN = 0,
-        PROVISIONED = 10,
-        PAY_PER_REQUEST = 20
+        Undefined = 0,
+        Provisioned = 10,
+        PayPerRequest = 20
     }
 }

--- a/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/IndexStatus.cs
+++ b/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/IndexStatus.cs
@@ -2,10 +2,10 @@ namespace EfficientDynamoDb.Operations.DescribeTable.Models.Enums
 {
     public enum IndexStatus
     {
-        _UNKNOWN = 0,
-        CREATING = 10,
-        UPDATING = 20,
-        DELETING = 30,
-        ACTIVE = 40
+        Undefined = 0,
+        Creating = 10,
+        Updating = 20,
+        Deleting = 30,
+        Active = 40
     }
 }

--- a/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/KeyType.cs
+++ b/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/KeyType.cs
@@ -2,8 +2,8 @@ namespace EfficientDynamoDb.Operations.DescribeTable.Models.Enums
 {
     public enum KeyType
     {
-        _UNKNOWN = 0,
-        HASH = 10,
-        RANGE = 20
+        Undefined = 0,
+        Hash = 10,
+        Range = 20
     }
 }

--- a/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/ProjectionType.cs
+++ b/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/ProjectionType.cs
@@ -2,9 +2,9 @@ namespace EfficientDynamoDb.Operations.DescribeTable.Models.Enums
 {
     public enum ProjectionType
     {
-        _UNKNOWN = 0,
-        KEYS_ONLY = 10,
-        INCLUDE = 20,
-        ALL = 30
+        Undefined = 0,
+        KeysOnly = 10,
+        Include = 20,
+        All = 30
     }
 }

--- a/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/ReplicaStatus.cs
+++ b/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/ReplicaStatus.cs
@@ -2,11 +2,11 @@ namespace EfficientDynamoDb.Operations.DescribeTable.Models.Enums
 {
     public enum ReplicaStatus
     {
-        _UNKNOWN = 0,
-        CREATING = 10,
-        UPDATING = 20,
-        DELETING = 30,
-        ACTIVE = 40,
-        REGION_DISABLED = 50
+        Undefined = 0,
+        Creating = 10,
+        Updating = 20,
+        Deleting = 30,
+        Active = 40,
+        RegionDisabled = 50
     }
 }

--- a/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/SseStatus.cs
+++ b/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/SseStatus.cs
@@ -4,14 +4,14 @@ namespace EfficientDynamoDb.Operations.DescribeTable.Models.Enums
 {
     public enum SseStatus
     {
-        _UNKNOWN = 0,
-        ENABLED = 10,
+        Undefined = 0,
+        Enabled = 10,
         [Obsolete("Not supported according to DDB docs")]
-        ENABLING = 20,
+        Enabling = 20,
         [Obsolete("Not supported according to DDB docs")]
-        DISABLED = 30,
+        Disabled = 30,
         [Obsolete("Not supported according to DDB docs")]
-        DISABLING = 40,
-        UPDATING = 50
+        Disabling = 40,
+        Updating = 50
     }
 }

--- a/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/SseType.cs
+++ b/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/SseType.cs
@@ -4,9 +4,9 @@ namespace EfficientDynamoDb.Operations.DescribeTable.Models.Enums
 {
     public enum SseType
     {
-        _UNKNOWN = 0,
-        KMS = 10,
+        Undefined = 0,
+        Kms = 10,
         [Obsolete("Not supported according to DDB docs")]
-        AES256 = 20
+        Aes256 = 20
     }
 }

--- a/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/StreamViewType.cs
+++ b/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/StreamViewType.cs
@@ -2,10 +2,10 @@ namespace EfficientDynamoDb.Operations.DescribeTable.Models.Enums
 {
     public enum StreamViewType
     {
-        _UNKNOWN = 0,
-        KEYS_ONLY = 10,
-        NEW_IMAGE = 20,
-        OLD_IMAGE = 30,
-        NEW_AND_OLD_IMAGES = 40
+        Undefined = 0,
+        KeysOnly = 10,
+        NewImage = 20,
+        OldImage = 30,
+        NewAndOldImages = 40
     }
 }

--- a/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/TableStatus.cs
+++ b/src/EfficientDynamoDb/Operations/DescribeTable/Models/Enums/TableStatus.cs
@@ -2,13 +2,13 @@ namespace EfficientDynamoDb.Operations.DescribeTable.Models.Enums
 {
     public enum TableStatus
     {
-        _UNKNOWN = 0,
-        CREATING = 10,
-        UPDATING = 20,
-        DELETING = 30,
-        ACTIVE = 40,
-        INACCESSIBLE_ENCRYPTION_CREDENTIALS = 50,
-        ARCHIVING = 60,
-        ARCHIVED = 70,
+        Undefined = 0,
+        Creating = 10,
+        Updating = 20,
+        Deleting = 30,
+        Active = 40,
+        InaccessibleEncryptionCredentials = 50,
+        Archiving = 60,
+        Archived = 70,
     }
 }


### PR DESCRIPTION
This change allows the use of PascalCase for enum values instead of UPPER_SNAKE_CASE used in DynamoDB API. 

This is a breaking change for [DescribeTable](https://github.com/AllocZero/EfficientDynamoDb/blob/e3e672f120d1a6f1365176da309413ad514cafd8/src/EfficientDynamoDb/DynamoDbManagementContext.cs#L20) call. But since it's the only control plane endpoint supported yet and most likely not widely used, it's a good moment to introduce a breaking change to have a better API moving forward. 