### PR TITLE
Refactor request URI handling to support multiple services

### DIFF
--- a/src/Benchmarks/Benchmarks/SignerBenchmark.cs
+++ b/src/Benchmarks/Benchmarks/SignerBenchmark.cs
@@ -36,7 +36,7 @@ namespace Benchmarks
             };
 
             var httpContent = new GetItemHttpContent(request, request.TableName, request.Key.PartitionKeyName!, request.Key.SortKeyName);
-            _httpRequest = new HttpRequestMessage(HttpMethod.Post, RegionEndpoint.USEast1.RequestUri)
+            _httpRequest = new HttpRequestMessage(HttpMethod.Post, RegionEndpoint.USEast1.BuildRequestUri(ServiceNames.DynamoDb))
             {
                 Content = httpContent
             };
@@ -52,7 +52,7 @@ namespace Benchmarks
             CleanupHeaders(_httpRequest);
             
             var meta = new SigningMetadata(RegionEndpoint.USEast1, new AwsCredentials("accessKey", "secretKey"), DateTime.UtcNow, 
-                _httpClient.DefaultRequestHeaders, null);
+                _httpClient.DefaultRequestHeaders, null, ServiceNames.DynamoDb);
             AwsRequestSigner.Sign(_httpRequest, _contentStream, meta);
 
             return _httpRequest;

--- a/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
+++ b/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
@@ -7,36 +7,46 @@ namespace EfficientDynamoDb.Configs
         private const string ChinaEndpointFormat = "https://{0}.{1}.amazonaws.com.cn"; // 0 - Service Name, 1 - Region
         private const string RegularEndpointFormat = "https://{0}.{1}.amazonaws.com"; // 0 - Service Name, 1 - Region
         
-        internal const string ServiceName = "dynamodb";
+        // internal const string ServiceName = "dynamodb";
 
-        internal string RequestUri { get; private set; }
-        
+        private readonly string? _requestUriOverride;
+
         public string Region { get; }
 
         public static RegionEndpoint Create(string region)
         {
-            var format =
-                region.StartsWith("cn-", StringComparison.OrdinalIgnoreCase)
-                ? ChinaEndpointFormat
-                : RegularEndpointFormat;
-
-            return new RegionEndpoint(region, format);
+            return new RegionEndpoint(region);
         }
 
         public static RegionEndpoint Create(string region, string requestUri)
         {
-            return new RegionEndpoint(region, RegularEndpointFormat) { RequestUri = requestUri };
+            return new RegionEndpoint(region, requestUri);
         }
 
         public static RegionEndpoint Create(RegionEndpoint region, string requestUri)
         {
-            return new RegionEndpoint(region.Region, RegularEndpointFormat) { RequestUri = requestUri };
+            return new RegionEndpoint(region.Region, requestUri);
         }
 
-        private RegionEndpoint(string region, string uriFormat = RegularEndpointFormat)
+        private RegionEndpoint(string region)
         {
             Region = region;
-            RequestUri = string.Format(uriFormat, ServiceName, region);
+        }
+
+        private RegionEndpoint(string region, string requestUriOverride) : this(region)
+        {
+            _requestUriOverride = requestUriOverride;
+        }
+
+        internal string BuildRequestUri(string serviceName)
+        {
+            if (!string.IsNullOrEmpty(_requestUriOverride))
+                return _requestUriOverride;
+
+            var format = Region.StartsWith("cn-", StringComparison.OrdinalIgnoreCase)
+                ? ChinaEndpointFormat
+                : RegularEndpointFormat;
+            return string.Format(format, serviceName, Region);
         }
 
         /// <summary>
@@ -122,12 +132,12 @@ namespace EfficientDynamoDb.Configs
         /// <summary>
         /// The China (Beijing) endpoint.
         /// </summary>
-        public static RegionEndpoint CNNorth1 => new RegionEndpoint("cn-north-1", ChinaEndpointFormat);
+        public static RegionEndpoint CNNorth1 => new RegionEndpoint("cn-north-1");
         
         /// <summary>
         /// The China (Ningxia) endpoint.
         /// </summary>
-        public static RegionEndpoint CNNorthWest1 => new RegionEndpoint("cn-northwest-1", ChinaEndpointFormat);
+        public static RegionEndpoint CNNorthWest1 => new RegionEndpoint("cn-northwest-1");
         
         /// <summary>
         /// The Europe (Frankfurt) endpoint.

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext,BatchWriteItem.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext,BatchWriteItem.cs
@@ -19,7 +19,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new BatchWriteItemHighLevelHttpContent(this, node, Config.TableNamePrefix);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var documentResult = await DynamoDbLowLevelContext.ReadDocumentAsync(response, BatchWriteItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
 
             var attempt = 0;
@@ -35,7 +35,7 @@ namespace EfficientDynamoDb
                 await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                 using var unprocessedHttpContent = new BatchWriteItemHttpContent(new BatchWriteItemRequest{RequestItems = unprocessedItems}, null);
             
-                using var unprocessedResponse = await Api.SendAsync(Config, unprocessedHttpContent, cancellationToken).ConfigureAwait(false);
+                using var unprocessedResponse = await Api.SendAsync(unprocessedHttpContent, cancellationToken).ConfigureAwait(false);
                 documentResult = await DynamoDbLowLevelContext.ReadDocumentAsync(unprocessedResponse, BatchWriteItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
             }
         }

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.BatchGetItem.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.BatchGetItem.cs
@@ -20,7 +20,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new BatchGetItemHighLevelHttpContent(this, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadAsync<BatchGetItemEntityResponse<TEntity>>(response, cancellationToken).ConfigureAwait(false);
             List<TEntity>? items = null;
             if (result.Responses?.Count > 0)
@@ -43,7 +43,7 @@ namespace EfficientDynamoDb
                 await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
                 using var unprocessedHttpContent = new BatchGetItemHttpContent(new BatchGetItemRequest {RequestItems = result.UnprocessedKeys}, null);
 
-                using var unprocessedResponse = await Api.SendAsync(Config, unprocessedHttpContent, cancellationToken).ConfigureAwait(false);
+                using var unprocessedResponse = await Api.SendAsync(unprocessedHttpContent, cancellationToken).ConfigureAwait(false);
                 result = await ReadAsync<BatchGetItemEntityResponse<TEntity>>(unprocessedResponse, cancellationToken).ConfigureAwait(false);
 
                 if (result.Responses?.Count > 0)

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.DeleteItem.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.DeleteItem.cs
@@ -30,7 +30,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new DeleteItemByPkObjectHttpContent<TEntity>(this, partitionKey);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
 
             await ReadAsync<object>(response, cancellationToken).ConfigureAwait(false);
         }
@@ -50,7 +50,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new DeleteItemByPkAndSkObjectHttpContent<TEntity>(this, partitionKey, sortKey);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
 
             await ReadAsync<object>(response, cancellationToken).ConfigureAwait(false);
         }
@@ -60,7 +60,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new DeleteItemHighLevelHttpContent(this, classInfo, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
 
             return await ReadAsync<DeleteItemEntityResponse<TEntity>>(response, cancellationToken).ConfigureAwait(false);
         }
@@ -70,7 +70,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new DeleteItemHighLevelHttpContent(this, classInfo, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
 
             var result = await ReadAsync<DeleteItemEntityProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
             return result.Attributes;
@@ -80,7 +80,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new DeleteItemHighLevelHttpContent(this, classInfo, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
 
             await ReadAsync<object>(response, cancellationToken).ConfigureAwait(false);
         }

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.GetItem.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.GetItem.cs
@@ -32,7 +32,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new GetItemByPkObjectHttpContent<TEntity>(this, partitionKey);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadAsync<GetItemEntityProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
 
             return result.Item;
@@ -55,7 +55,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new GetItemByPkAndSkObjectHttpContent<TEntity>(this, partitionKey, sortKey);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadAsync<GetItemEntityProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
 
             return result.Item;
@@ -98,7 +98,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new GetItemHighLevelHttpContent(this, classInfo, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadAsync<GetItemEntityProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
 
             return result.Item;
@@ -108,7 +108,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new GetItemHighLevelHttpContent(this, classInfo, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             return await ReadAsync<GetItemEntityResponse<TEntity>>(response, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.PutItem.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.PutItem.cs
@@ -31,7 +31,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new PutItemHighLevelHttpContent(this, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
 
             return await ReadAsync<PutItemEntityResponse<TEntity>>(response, cancellationToken).ConfigureAwait(false);
         }
@@ -41,7 +41,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new PutItemHighLevelHttpContent(this, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
 
             var result = await ReadAsync<PutItemEntityProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
             return result.Item;

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.Query.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.Query.cs
@@ -29,7 +29,7 @@ namespace EfficientDynamoDb
                 var contentNode = isFirst ? node : new PaginationTokenNode(result?.PaginationToken, node);
                 using var httpContent = new QueryHighLevelHttpContent(this, tableName, contentNode);
 
-                using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+                using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
                 result = await ReadAsync<QueryEntityResponseProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
 
                 if (items == null)
@@ -47,7 +47,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new QueryHighLevelHttpContent(this, tableName, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadAsync<QueryEntityResponseProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
 
             return new PagedResult<TEntity>(result.Items, result.PaginationToken);
@@ -64,7 +64,7 @@ namespace EfficientDynamoDb
                 var contentNode = isFirst ? node : new PaginationTokenNode(result?.PaginationToken, node);
                 using var httpContent = new QueryHighLevelHttpContent(this, tableName, contentNode);
 
-                using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+                using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
                 result = await ReadAsync<QueryEntityResponseProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
 
                 yield return result.Items;
@@ -78,7 +78,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new QueryHighLevelHttpContent(this, tableName, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             return await ReadAsync<QueryEntityResponse<TEntity>>(response, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.Scan.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.Scan.cs
@@ -22,7 +22,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new ScanHighLevelHttpContent(this, tableName, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadAsync<ScanEntityResponseProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
 
             return new PagedResult<TEntity>(result.Items, result.PaginationToken);
@@ -38,7 +38,7 @@ namespace EfficientDynamoDb
                 var contentNode = isFirst ? node : new PaginationTokenNode(result?.PaginationToken, node);
                 using var httpContent = new ScanHighLevelHttpContent(this, tableName, contentNode);
 
-                using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+                using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
                 result = await ReadAsync<ScanEntityResponseProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
 
                 yield return result.Items;
@@ -54,7 +54,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new ScanHighLevelHttpContent(this, tableName, node);
             
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             return await ReadAsync<ScanEntityResponse<TEntity>>(response, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.TransactGetItems.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.TransactGetItems.cs
@@ -19,7 +19,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new TransactGetItemsHighLevelHttpContent(this, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadAsync<TransactGetItemsEntityProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
             var entities = new List<TEntity?>(result.Responses.Count);
             foreach (var item in result.Responses)
@@ -32,7 +32,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new TransactGetItemsHighLevelHttpContent(this, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             return await ReadAsync<TransactGetItemsEntityResponse<TEntity>>(response, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.TransactWriteItems.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.TransactWriteItems.cs
@@ -19,7 +19,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new TransactWriteItemsHighLevelHttpContent(this, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             await ReadAsync<object>(response, cancellationToken).ConfigureAwait(false);
         }
         
@@ -27,7 +27,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new TransactWriteItemsHighLevelHttpContent(this, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             return await ReadAsync<TransactWriteItemsEntityResponse>(response, cancellationToken).ConfigureAwait(false);
         }
     }

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.UpdateItem.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.UpdateItem.cs
@@ -21,7 +21,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new UpdateItemHighLevelHttpContent(this, classInfo, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
 
             return await ReadAsync<UpdateItemEntityResponse<TEntity>>(response, cancellationToken).ConfigureAwait(false);
         }
@@ -31,7 +31,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new UpdateItemHighLevelHttpContent(this, classInfo, node);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
 
             var result =  await ReadAsync<UpdateItemEntityProjection<TEntity>>(response, cancellationToken).ConfigureAwait(false);
             return result.Item;

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using EfficientDynamoDb.DocumentModel;
 using EfficientDynamoDb.Exceptions;
 using EfficientDynamoDb.Internal;
+using EfficientDynamoDb.Internal.Constants;
 using EfficientDynamoDb.Internal.Converters.Json;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Reader;
@@ -28,7 +29,7 @@ namespace EfficientDynamoDb
 
         public DynamoDbContext(DynamoDbContextConfig config)
         {
-            _lowContext = new DynamoDbLowLevelContext(config, new HttpApi(config.HttpClientFactory));
+            _lowContext = new DynamoDbLowLevelContext(config, new HttpApi(config, ServiceNames.DynamoDb));
         }
 
         public T ToObject<T>(Document document) where T : class => document.ToObject<T>(Config.Metadata);
@@ -37,7 +38,7 @@ namespace EfficientDynamoDb
 
         async Task<TResponse> IDynamoDbContext.ExecuteAsync<TResponse>(HttpContent httpContent, CancellationToken cancellationToken) where TResponse : class
         {
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             return await ReadAsync<TResponse>(response, cancellationToken).ConfigureAwait(false);
         }
 

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbLowLevelContext.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbLowLevelContext.cs
@@ -56,7 +56,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new BatchGetItemHttpContent(request, Config.TableNamePrefix);
             
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, BatchGetItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
 
             return BatchGetItemResponseParser.Parse(result!);
@@ -66,7 +66,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new BatchWriteItemHttpContent(request, Config.TableNamePrefix);
             
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, BatchWriteItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
 
             return BatchWriteItemResponseParser.Parse(result!);
@@ -76,7 +76,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new QueryHttpContent(request, Config.TableNamePrefix);
             
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, QueryParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
 
             return QueryResponseParser.Parse(result!);
@@ -86,7 +86,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new ScanHttpContent(request, Config.TableNamePrefix);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, QueryParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
 
             return ScanResponseParser.Parse(result!);
@@ -96,7 +96,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new TransactGetItemsHttpContent(request, Config.TableNamePrefix);
 
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, TransactGetItemsParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
 
             return TransactGetItemsResponseParser.Parse(result!);
@@ -106,7 +106,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new PutItemHttpContent(request, Config.TableNamePrefix);
             
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, PutItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
 
             return PutItemResponseParser.Parse(result);
@@ -116,7 +116,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = await BuildHttpContentAsync(request).ConfigureAwait(false);
             
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, UpdateItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
 
             return UpdateItemResponseParser.Parse(result);
@@ -130,7 +130,7 @@ namespace EfficientDynamoDb
 
             using var httpContent = new DeleteItemHttpContent(request, pkName, skName, Config.TableNamePrefix);
             
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, PutItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
 
             return DeleteItemResponseParser.Parse(result);
@@ -140,7 +140,7 @@ namespace EfficientDynamoDb
         {
             using var httpContent = new TransactWriteItemsHttpContent(request, Config.TableNamePrefix);
             
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, TransactWriteItemsParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
 
             return TransactWriteItemsResponseParser.Parse(result);
@@ -152,7 +152,7 @@ namespace EfficientDynamoDb
 
         private async ValueTask<GetItemResponse> GetItemInternalAsync(HttpContent httpContent, CancellationToken cancellationToken = default)
         {
-            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            using var response = await Api.SendAsync(httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, GetItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
 
             // TODO: Consider removing root dictionary
@@ -189,7 +189,7 @@ namespace EfficientDynamoDb
             
             async Task<(string Pk, string? Sk)> CreateKeyNamesTaskAsync(string table)
             {
-                var response = await Api.SendAsync<DescribeTableResponse>(Config, new DescribeTableRequestHttpContent(Config.TableNamePrefix, tableName))
+                var response = await Api.SendAsync<DescribeTableResponse>(new DescribeTableRequestHttpContent(Config.TableNamePrefix, tableName))
                     .ConfigureAwait(false);
 
                 var keySchema = response.Table.KeySchema;

--- a/src/EfficientDynamoDb/DynamoDbManagementContext.cs
+++ b/src/EfficientDynamoDb/DynamoDbManagementContext.cs
@@ -1,6 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using EfficientDynamoDb.Internal;
+using EfficientDynamoDb.Internal.Constants;
 using EfficientDynamoDb.Internal.Operations.DescribeTable;
 using EfficientDynamoDb.Operations.DescribeTable;
 
@@ -13,7 +14,7 @@ namespace EfficientDynamoDb
 
         public DynamoDbManagementContext(DynamoDbContextConfig config)
         {
-            _api = new HttpApi(config.HttpClientFactory);
+            _api = new HttpApi(config, ServiceNames.DynamoDb);
             _config = config;
         }
 
@@ -21,7 +22,7 @@ namespace EfficientDynamoDb
         {
             var httpContent = new DescribeTableRequestHttpContent(_config.TableNamePrefix, tableName);
 
-            var response = await _api.SendAsync<DescribeTableResponse>(_config, httpContent, cancellationToken).ConfigureAwait(false);
+            var response = await _api.SendAsync<DescribeTableResponse>(httpContent, cancellationToken).ConfigureAwait(false);
 
             return response;
         }

--- a/src/EfficientDynamoDb/Internal/Constants/ServiceNames.cs
+++ b/src/EfficientDynamoDb/Internal/Constants/ServiceNames.cs
@@ -3,6 +3,7 @@ namespace EfficientDynamoDb.Internal.Constants
     internal static class ServiceNames
     {
         public const string DynamoDb = "dynamodb";
+        public const string DynamoDbStreams = "streams.dynamodb";
         public const string S3 = "s3";
     }
 }

--- a/src/EfficientDynamoDb/Internal/Extensions/NoAllocStringBuilderExtensions.cs
+++ b/src/EfficientDynamoDb/Internal/Extensions/NoAllocStringBuilderExtensions.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using EfficientDynamoDb.Configs;
+using EfficientDynamoDb.Internal.Constants;
 using EfficientDynamoDb.Internal.Core;
 using EfficientDynamoDb.Internal.Signing;
 using EfficientDynamoDb.Internal.Signing.Constants;
@@ -15,7 +16,7 @@ namespace EfficientDynamoDb.Internal.Extensions
             builder.Append('/');
             builder.Append(metadata.RegionEndpoint.Region);
             builder.Append('/');
-            builder.Append(metadata.ServiceName);
+            builder.Append(ServiceNames.DynamoDb);
             builder.Append('/');
             builder.Append(SigningConstants.AwsSignTerminator);
         }

--- a/src/EfficientDynamoDb/Internal/Extensions/NoAllocStringBuilderExtensions.cs
+++ b/src/EfficientDynamoDb/Internal/Extensions/NoAllocStringBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace EfficientDynamoDb.Internal.Extensions
             builder.Append('/');
             builder.Append(metadata.RegionEndpoint.Region);
             builder.Append('/');
-            builder.Append(RegionEndpoint.ServiceName);
+            builder.Append(metadata.ServiceName);
             builder.Append('/');
             builder.Append(SigningConstants.AwsSignTerminator);
         }

--- a/src/EfficientDynamoDb/Internal/Signing/AwsRequestSigner.cs
+++ b/src/EfficientDynamoDb/Internal/Signing/AwsRequestSigner.cs
@@ -16,7 +16,7 @@ namespace EfficientDynamoDb.Internal.Signing
 
         public static void Sign(HttpRequestMessage request, RecyclableMemoryStream content, in SigningMetadata metadata)
         {
-            ValidateInput(request, RegionEndpoint.ServiceName);
+            ValidateInput(request, metadata.ServiceName);
             UpdateRequestUri(metadata.BaseAddress, request);
 
             request.Headers.Add(HeaderKeys.XAmzDateHeader, metadata.TimestampIso8601BasicDateTimeString);
@@ -36,7 +36,8 @@ namespace EfficientDynamoDb.Internal.Signing
             {
                 CanonicalRequestBuilder.Build(request, in contentHash, in metadata, ref builder, ref signedHeadersBuilder);
                 StringToSignBuilder.Build(ref builder, in metadata);
-                var authorizationHeader = AuthorizationHeaderBuilder.Build(ref builder, ref signedHeadersBuilder, in metadata);
+                var authorizationHeader = AuthorizationHeaderBuilder.
+                    Build(ref builder, ref signedHeadersBuilder, in metadata);
                 
                 request.Headers.TryAddWithoutValidation(HeaderKeys.AuthorizationHeader, authorizationHeader);
             }

--- a/src/EfficientDynamoDb/Internal/Signing/Builders/AuthorizationHeaderBuilder.cs
+++ b/src/EfficientDynamoDb/Internal/Signing/Builders/AuthorizationHeaderBuilder.cs
@@ -55,7 +55,7 @@ namespace EfficientDynamoDb.Internal.Signing.Builders
                 ComputeKeyedSha256Hash(algorithm, ref sourceDataBuffer, ref destinationDataBuffer, ref keysBuffer, metadata.RegionEndpoint.Region);
                 algorithm.Key = keysBuffer;
 
-                ComputeKeyedSha256Hash(algorithm, ref sourceDataBuffer, ref destinationDataBuffer, ref keysBuffer, metadata.ServiceName);
+                ComputeKeyedSha256Hash(algorithm, ref sourceDataBuffer, ref destinationDataBuffer, ref keysBuffer, ServiceNames.DynamoDb);
                 algorithm.Key = keysBuffer;
                 
                 ComputeKeyedSha256Hash(algorithm, ref sourceDataBuffer, ref destinationDataBuffer, ref keysBuffer, SigningConstants.AwsSignTerminator);

--- a/src/EfficientDynamoDb/Internal/Signing/Builders/AuthorizationHeaderBuilder.cs
+++ b/src/EfficientDynamoDb/Internal/Signing/Builders/AuthorizationHeaderBuilder.cs
@@ -54,8 +54,8 @@ namespace EfficientDynamoDb.Internal.Signing.Builders
                 
                 ComputeKeyedSha256Hash(algorithm, ref sourceDataBuffer, ref destinationDataBuffer, ref keysBuffer, metadata.RegionEndpoint.Region);
                 algorithm.Key = keysBuffer;
-                
-                ComputeKeyedSha256Hash(algorithm, ref sourceDataBuffer, ref destinationDataBuffer, ref keysBuffer, RegionEndpoint.ServiceName);
+
+                ComputeKeyedSha256Hash(algorithm, ref sourceDataBuffer, ref destinationDataBuffer, ref keysBuffer, metadata.ServiceName);
                 algorithm.Key = keysBuffer;
                 
                 ComputeKeyedSha256Hash(algorithm, ref sourceDataBuffer, ref destinationDataBuffer, ref keysBuffer, SigningConstants.AwsSignTerminator);

--- a/src/EfficientDynamoDb/Internal/Signing/Models/SigningMetadata.cs
+++ b/src/EfficientDynamoDb/Internal/Signing/Models/SigningMetadata.cs
@@ -23,9 +23,11 @@ namespace EfficientDynamoDb.Internal.Signing
         public bool HasDefaultRequestHeaders { get; }
 
         public Uri? BaseAddress { get; }
+        
+        public string ServiceName { get; }
 
         public SigningMetadata(RegionEndpoint regionEndpoint, AwsCredentials credentials, in DateTime timestamp,
-            HttpRequestHeaders defaultRequestHeaders, Uri? baseAddress)
+            HttpRequestHeaders defaultRequestHeaders, Uri? baseAddress, string serviceName)
         {
             RegionEndpoint = regionEndpoint;
             Credentials = credentials;
@@ -33,6 +35,7 @@ namespace EfficientDynamoDb.Internal.Signing
             DefaultRequestHeaders = defaultRequestHeaders;
             HasDefaultRequestHeaders = defaultRequestHeaders.Any();
             BaseAddress = baseAddress;
+            ServiceName = serviceName;
         }
     }
 }


### PR DESCRIPTION
This PR enables using different endpoints for different DynamoDB services. E.g. DynamoDB Streams API endpoints [use different convention](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html#Streams.Endpoints) `streams.dynamodb.<region>.amazonaws.com` instead of regular `dynamodb.<region>.amazonaws.com`.