### PR TITLE
Improvements to consumed capacity parsing

### DIFF
--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext,BatchWriteItem.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext,BatchWriteItem.cs
@@ -1,9 +1,14 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using EfficientDynamoDb.Exceptions;
 using EfficientDynamoDb.Internal.Operations.BatchWriteItem;
+using EfficientDynamoDb.Internal.Operations.Shared;
 using EfficientDynamoDb.Operations.BatchWriteItem;
 using EfficientDynamoDb.Operations.Query;
+using EfficientDynamoDb.Operations.Shared;
+using EfficientDynamoDb.Operations.Shared.Capacity;
 
 namespace EfficientDynamoDb
 {
@@ -37,6 +42,105 @@ namespace EfficientDynamoDb
             
                 using var unprocessedResponse = await Api.SendAsync(Config, unprocessedHttpContent, cancellationToken).ConfigureAwait(false);
                 documentResult = await DynamoDbLowLevelContext.ReadDocumentAsync(unprocessedResponse, BatchWriteItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        
+        internal async Task<BatchWriteItemResponse> BatchWriteItemResponseAsync(BuilderNode node, CancellationToken cancellationToken = default)
+        {
+            using var httpContent = new BatchWriteItemHighLevelHttpContent(this, node, Config.TableNamePrefix);
+
+            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            var documentResult = await DynamoDbLowLevelContext.ReadDocumentAsync(response, BatchWriteItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
+            if (documentResult == null)
+                return new BatchWriteItemResponse(null, null, null);
+
+            var unprocessedItems = BatchWriteItemResponseParser.ParseFailedItems(documentResult);
+            var consumedCapacity = CapacityParser.ParseFullConsumedCapacities(documentResult);
+            var itemCollectionMetrics = ItemCollectionMetricsParser.ParseMultipleItemCollectionMetrics(documentResult);
+
+            var attempt = 0;
+            while (unprocessedItems != null && unprocessedItems.Count > 0)
+            {
+                if (!Config.RetryStrategies.ProvisionedThroughputExceededStrategy.TryGetRetryDelay(attempt++, out var delay))
+                    throw new DdbException($"Maximum number of {attempt} attempts exceeded while executing batch write item request.");
+
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                using var unprocessedHttpContent = new BatchWriteItemHttpContent(new BatchWriteItemRequest{RequestItems = unprocessedItems}, null);
+            
+                using var unprocessedResponse = await Api.SendAsync(Config, unprocessedHttpContent, cancellationToken).ConfigureAwait(false);
+                documentResult = await DynamoDbLowLevelContext.ReadDocumentAsync(unprocessedResponse, BatchWriteItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
+                if (documentResult == null)
+                    break;
+                
+                unprocessedItems = BatchWriteItemResponseParser.ParseFailedItems(documentResult);
+                MergeFullCapacities(ref consumedCapacity, CapacityParser.ParseFullConsumedCapacities(documentResult));
+                MergeItemCollectionMetrics(ref itemCollectionMetrics, ItemCollectionMetricsParser.ParseMultipleItemCollectionMetrics(documentResult));
+            }
+
+            return new BatchWriteItemResponse(consumedCapacity, itemCollectionMetrics, unprocessedItems);
+        }
+
+        private static void MergeFullCapacities(ref List<FullConsumedCapacity>? total, List<FullConsumedCapacity>? current)
+        {
+            if (current == null)
+                return;
+
+            if (total == null)
+            {
+                total = current;
+                return;
+            }
+
+            foreach (var capacity in current)
+            {
+                var idx = total.FindIndex(x => x.TableName == capacity.TableName);
+                if (idx == -1)
+                    total.Add(capacity);
+                else
+                {
+                    var totalCapacity = total[idx];
+                    totalCapacity.CapacityUnits += capacity.CapacityUnits;
+                    totalCapacity.GlobalSecondaryIndexes = MergeIndexConsumedCapacities(totalCapacity.GlobalSecondaryIndexes, capacity.GlobalSecondaryIndexes);
+                    totalCapacity.LocalSecondaryIndexes = MergeIndexConsumedCapacities(totalCapacity.LocalSecondaryIndexes, capacity.LocalSecondaryIndexes);
+                }
+            }
+        }
+
+        private static IReadOnlyDictionary<string, ConsumedCapacity>? MergeIndexConsumedCapacities(IReadOnlyDictionary<string, ConsumedCapacity>? total,
+            IReadOnlyDictionary<string, ConsumedCapacity>? current)
+        {
+            if (current == null)
+                return total;
+            if (total == null)
+                return current;
+            
+            var tempDict = total.ToDictionary(x => x.Key, x => x.Value);
+            foreach (var capacity in current)
+            {
+                if (tempDict.TryGetValue(capacity.Key, out var totalCapacity))
+                    totalCapacity.CapacityUnits += capacity.Value.CapacityUnits;
+                else
+                {
+                    tempDict[capacity.Key] = capacity.Value;
+                }
+            }
+
+            return tempDict;
+        }
+        
+        private static void MergeItemCollectionMetrics(ref Dictionary<string, ItemCollectionMetrics>? total, Dictionary<string, ItemCollectionMetrics>? current)
+        {
+            if (current == null)
+                return;
+            if (total == null)
+            {
+                total = current;
+                return;
+            }
+            
+            foreach (var metrics in total)
+            {
+                total[metrics.Key] = metrics.Value;
             }
         }
     }

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.BatchGetItem.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.BatchGetItem.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -5,6 +6,7 @@ using EfficientDynamoDb.Exceptions;
 using EfficientDynamoDb.Internal.Operations.BatchGetItem;
 using EfficientDynamoDb.Operations.BatchGetItem;
 using EfficientDynamoDb.Operations.Query;
+using EfficientDynamoDb.Operations.Shared.Capacity;
 
 namespace EfficientDynamoDb
 {
@@ -16,23 +18,15 @@ namespace EfficientDynamoDb
         /// <returns>BatchGet operation builder.</returns>
         public IBatchGetEntityRequestBuilder BatchGet() => new BatchGetEntityRequestBuilder(this);
         
-        internal async Task<List<TEntity>> BatchGetItemAsync<TEntity>(BuilderNode node, CancellationToken cancellationToken = default) where TEntity : class
+        internal async Task<List<TEntity>> BatchGetItemListAsync<TEntity>(BuilderNode node, CancellationToken cancellationToken = default) where TEntity : class
         {
             using var httpContent = new BatchGetItemHighLevelHttpContent(this, node);
 
             using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadAsync<BatchGetItemEntityResponse<TEntity>>(response, cancellationToken).ConfigureAwait(false);
+            
             List<TEntity>? items = null;
-            if (result.Responses?.Count > 0)
-            {
-                foreach (var values in result.Responses.Values)
-                {
-                    if (items == null)
-                        items = values;
-                    else
-                        items.AddRange(values);
-                }
-            }
+            ExtractItems(ref items, result.Responses);
 
             var attempt = 0;
             while (result.UnprocessedKeys?.Count > 0)
@@ -46,19 +40,76 @@ namespace EfficientDynamoDb
                 using var unprocessedResponse = await Api.SendAsync(Config, unprocessedHttpContent, cancellationToken).ConfigureAwait(false);
                 result = await ReadAsync<BatchGetItemEntityResponse<TEntity>>(unprocessedResponse, cancellationToken).ConfigureAwait(false);
 
-                if (result.Responses?.Count > 0)
-                {
-                    foreach (var values in result.Responses.Values)
-                    {
-                        if (items == null)
-                            items = values;
-                        else
-                            items.AddRange(values);
-                    }
-                }
+                ExtractItems(ref items, result.Responses);
             }
 
             return items ?? new List<TEntity>();
+        }
+        
+        internal async Task<BatchGetItemResponse<TEntity>> BatchGetItemResponseAsync<TEntity>(BuilderNode node, CancellationToken cancellationToken = default) where TEntity : class
+        {
+            using var httpContent = new BatchGetItemHighLevelHttpContent(this, node);
+            using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
+            var apiResult = await ReadAsync<BatchGetItemEntityResponse<TEntity>>(response, cancellationToken).ConfigureAwait(false);
+            
+            List<TEntity>? items = null;
+            ExtractItems(ref items, apiResult.Responses);
+            var totalConsumedCapacity = apiResult.ConsumedCapacity;
+            
+            var attempt = 0;
+            while (apiResult.UnprocessedKeys?.Count > 0)
+            {
+                if (!Config.RetryStrategies.ProvisionedThroughputExceededStrategy.TryGetRetryDelay(attempt++, out var delay))
+                    break;
+
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+                using var unprocessedHttpContent = new BatchGetItemHttpContent(new BatchGetItemRequest {RequestItems = apiResult.UnprocessedKeys}, null);
+                
+                using var unprocessedResponse = await Api.SendAsync(Config, unprocessedHttpContent, cancellationToken).ConfigureAwait(false);
+                apiResult = await ReadAsync<BatchGetItemEntityResponse<TEntity>>(unprocessedResponse, cancellationToken).ConfigureAwait(false);
+                
+                ExtractItems(ref items, apiResult.Responses);
+                MergeCapacity(ref totalConsumedCapacity, apiResult.ConsumedCapacity);
+            }
+
+            return new BatchGetItemResponse<TEntity>(totalConsumedCapacity, items ?? (IReadOnlyList<TEntity>)Array.Empty<TEntity>(), apiResult.UnprocessedKeys);
+        }
+
+        private static void ExtractItems<TEntity>(ref List<TEntity>? items, IReadOnlyDictionary<string, List<TEntity>>? responses)
+        {
+            if (responses == null || responses.Count == 0)
+                return;
+
+            foreach (var values in responses.Values)
+            {
+                if (items == null)
+                    items = values;
+                else
+                    items.AddRange(values);
+            }
+        }
+
+        private static void MergeCapacity(ref List<TableConsumedCapacity>? total, List<TableConsumedCapacity>? current)
+        {
+            if (current == null)
+                return;
+            if (total == null || total.Count == 0)
+            {
+                total = current;
+                return;
+            }
+            
+            // It's ok to use O(n^2) here because:
+            // - this method is called only when there are unprocessed keys
+            // - transforming total to dictionary and back is slower until there are more than ~20 tables in the request (assuming single retry).
+            foreach (var currentCapacity in current)
+            {
+                var idx = total.FindIndex(x => x.TableName == currentCapacity.TableName);
+                if (idx >= 0)
+                    total[idx].CapacityUnits += currentCapacity.CapacityUnits;
+                else
+                    total.Add(currentCapacity);
+            }
         }
     }
 }

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.BatchGetItem.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext.BatchGetItem.cs
@@ -69,7 +69,7 @@ namespace EfficientDynamoDb
                 apiResult = await ReadAsync<BatchGetItemEntityResponse<TEntity>>(unprocessedResponse, cancellationToken).ConfigureAwait(false);
                 
                 ExtractItems(ref items, apiResult.Responses);
-                MergeCapacity(ref totalConsumedCapacity, apiResult.ConsumedCapacity);
+                MergeTableCapacities(ref totalConsumedCapacity, apiResult.ConsumedCapacity);
             }
 
             return new BatchGetItemResponse<TEntity>(totalConsumedCapacity, items ?? (IReadOnlyList<TEntity>)Array.Empty<TEntity>(), apiResult.UnprocessedKeys);
@@ -89,7 +89,7 @@ namespace EfficientDynamoDb
             }
         }
 
-        private static void MergeCapacity(ref List<TableConsumedCapacity>? total, List<TableConsumedCapacity>? current)
+        private static void MergeTableCapacities(ref List<TableConsumedCapacity>? total, List<TableConsumedCapacity>? current)
         {
             if (current == null)
                 return;

--- a/src/EfficientDynamoDb/Internal/Operations/BatchWriteItem/BatchGetItemResponseParser.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/BatchWriteItem/BatchGetItemResponseParser.cs
@@ -11,7 +11,7 @@ namespace EfficientDynamoDb.Internal.Operations.BatchWriteItem
         public static BatchWriteItemResponse Parse(Document? response) =>
             response == null
                 ? new BatchWriteItemResponse(null, null, null)
-                : new BatchWriteItemResponse(CapacityParser.ParseTableConsumedCapacities(response), ItemCollectionMetricsParser.ParseMultipleItemCollectionMetrics(response),
+                : new BatchWriteItemResponse(CapacityParser.ParseFullConsumedCapacities(response), ItemCollectionMetricsParser.ParseMultipleItemCollectionMetrics(response),
                     ParseFailedItems(response));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/EfficientDynamoDb/Internal/Operations/Shared/ItemCollectionMetricsParser.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/Shared/ItemCollectionMetricsParser.cs
@@ -18,7 +18,7 @@ namespace EfficientDynamoDb.Internal.Operations.Shared
             return ParseSingle(metricsDocument);
         }
         
-        public static IReadOnlyDictionary<string, ItemCollectionMetrics>? ParseMultipleItemCollectionMetrics(Document response)
+        public static Dictionary<string, ItemCollectionMetrics>? ParseMultipleItemCollectionMetrics(Document response)
         {
             if(!response.TryGetValue("ItemCollectionMetrics", out var metricsAttribute))
                 return null;

--- a/src/EfficientDynamoDb/Internal/Operations/TransactWriteItems/TransactWriteItemsResponseParser.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/TransactWriteItems/TransactWriteItemsResponseParser.cs
@@ -10,7 +10,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
         {
             return response == null
                 ? new TransactWriteItemsResponse(null, null)
-                : new TransactWriteItemsResponse(CapacityParser.ParseFullConsumedCapacity(response), ItemCollectionMetricsParser.ParseMultipleItemCollectionMetrics(response));
+                : new TransactWriteItemsResponse(CapacityParser.ParseFullConsumedCapacities(response), ItemCollectionMetricsParser.ParseMultipleItemCollectionMetrics(response));
         }
     }
 }

--- a/src/EfficientDynamoDb/Operations/BatchGetItem/BatchGetItemResponse.cs
+++ b/src/EfficientDynamoDb/Operations/BatchGetItem/BatchGetItemResponse.cs
@@ -33,7 +33,6 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
         /// <summary>
         /// A map of tables and their respective keys that were not processed with the current response.
         /// The <c>UnprocessedKeys</c> value is in the same form as <see cref="BatchGetItemRequest.RequestItems"/>, so the value can be provided directly to a subsequent BatchGetItem operation.
-        /// 
         /// </summary>
         public IReadOnlyDictionary<string, TableBatchGetItemRequest>? UnprocessedKeys { get; }
 
@@ -42,6 +41,44 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
         {
             ConsumedCapacity = consumedCapacity;
             Responses = responses;
+            UnprocessedKeys = unprocessedKeys;
+        }
+    }
+
+    public class BatchGetItemResponse<TEntity>
+    {
+        /// <summary>
+        /// <para>The read capacity units consumed by the entire <c>BatchGetItem</c> operation.</para>
+        /// <list type="bullet">
+        /// <listheader>
+        /// Each element consists of:
+        /// </listheader>
+        /// <item>
+        /// <c>TableName</c> - The table that consumed the provisioned throughput.
+        /// </item>
+        /// <item>
+        /// <c>CapacityUnits</c> - The total number of capacity units consumed.
+        /// </item>
+        /// </list>
+        /// </summary>
+        public IReadOnlyList<TableConsumedCapacity>? ConsumedCapacity { get; }
+
+        /// <summary>
+        /// A list of successfully retrieved items.
+        /// </summary>
+        public IReadOnlyList<TEntity> Items { get; }
+
+        /// <summary>
+        /// A map of tables and their respective keys that were not processed with the current response.
+        /// The <c>UnprocessedKeys</c> value is in the same form as <see cref="BatchGetItemRequest.RequestItems"/>, so the value can be provided directly to a subsequent BatchGetItem operation.
+        /// </summary>
+        public IReadOnlyDictionary<string, TableBatchGetItemRequest>? UnprocessedKeys { get; }
+
+        public BatchGetItemResponse(IReadOnlyList<TableConsumedCapacity>? consumedCapacity, IReadOnlyList<TEntity> items,
+            IReadOnlyDictionary<string, TableBatchGetItemRequest>? unprocessedKeys)
+        {
+            ConsumedCapacity = consumedCapacity;
+            Items = items;
             UnprocessedKeys = unprocessedKeys;
         }
     }
@@ -61,6 +98,23 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
         /// </summary>
         [DynamoDbProperty("UnprocessedKeys", typeof(JsonBatchGetItemUnprocessedKeysConverter))]
         public IReadOnlyDictionary<string, TableBatchGetItemRequest>? UnprocessedKeys { get; set; }
+        
+        /// <summary>
+        /// <para>The read capacity units consumed by the entire <c>BatchGetItem</c> operation.</para>
+        /// <list type="bullet">
+        /// <listheader>
+        /// Each element consists of:
+        /// </listheader>
+        /// <item>
+        /// <c>TableName</c> - The table that consumed the provisioned throughput.
+        /// </item>
+        /// <item>
+        /// <c>CapacityUnits</c> - The total number of capacity units consumed.
+        /// </item>
+        /// </list>
+        /// </summary>
+        [DynamoDbProperty("ConsumedCapacity", typeof(JsonListDdbConverter<>))]
+        public List<TableConsumedCapacity>? ConsumedCapacity { get; set; }
     }
 
     internal sealed class JsonBatchGetItemResponsesConverter<TKey, TValue> : JsonIReadOnlyDictionaryDdbConverter<TKey, TValue> where TKey : notnull

--- a/src/EfficientDynamoDb/Operations/BatchGetItem/IBatchGetRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchGetItem/IBatchGetRequestBuilder.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using EfficientDynamoDb.DocumentModel;
+using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.BatchGetItem
 {
@@ -17,6 +18,14 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
         /// <typeparam name="TEntity">Type of the DB entity.</typeparam>
         /// <returns>A task that represents the asynchronous operation.</returns>
         Task<List<TEntity>> ToListAsync<TEntity>(CancellationToken cancellationToken = default) where TEntity : class;
+        
+        /// <summary>
+        /// Executes the BatchGet operation and returns the deserialized response.
+        /// </summary>
+        /// <param name="cancellationToken">Token that can be used to cancel the task.</param>
+        /// <typeparam name="TEntity">Type of the DB entity.</typeparam>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task<BatchGetItemResponse<TEntity>> ToResponseAsync<TEntity>(CancellationToken cancellationToken = default) where TEntity : class;
 
         /// <summary>
         /// Configures the operation to retrieve data from one or multiple tables in a batch.
@@ -55,6 +64,13 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
         IBatchGetEntityRequestBuilder WithItems(IEnumerable<IBatchGetItemBuilder> items);
 
         /// <summary>
+        /// Specifies the consumed capacity details to include in the response.
+        /// </summary>
+        /// <param name="returnConsumedCapacity">The <see cref="ReturnConsumedCapacity"/> option.</param>
+        /// <returns>BatchGet operation builder.</returns>
+        IBatchGetEntityRequestBuilder WithReturnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity);
+
+        /// <summary>
         /// Represents the returned items as <see cref="Document"/>.
         /// </summary>
         /// <returns>BatchGet operation builder suitable for document response.</returns>
@@ -74,6 +90,14 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
         /// <param name="cancellationToken">Token that can be used to cancel the task.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         Task<List<Document>> ToListAsync(CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Executes the BatchGet operation and returns the deserialized response.
+        /// Every entity in the response is represented as <see cref="Document"/>.
+        /// </summary>
+        /// <param name="cancellationToken">Token that can be used to cancel the task.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task<BatchGetItemResponse<Document>> ToResponseAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Configures the operation to retrieve data from one or multiple tables in a batch.
@@ -110,5 +134,12 @@ namespace EfficientDynamoDb.Operations.BatchGetItem
         /// Use <see cref="Batch"/> static class to construct item builders.
         /// </remarks>
         IBatchGetDocumentRequestBuilder WithItems(IEnumerable<IBatchGetItemBuilder> items);
+        
+        /// <summary>
+        /// Specifies the consumed capacity details to include in the response.
+        /// </summary>
+        /// <param name="returnConsumedCapacity">The <see cref="ReturnConsumedCapacity"/> option.</param>
+        /// <returns>BatchGet operation builder.</returns>
+        IBatchGetDocumentRequestBuilder WithReturnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity);
     }
 }

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchWriteItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchWriteItemRequestBuilder.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EfficientDynamoDb.Exceptions;
 using EfficientDynamoDb.Operations.Query;
+using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.BatchWriteItem
 {
@@ -28,6 +29,13 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
         public IBatchWriteItemRequestBuilder WithItems(IEnumerable<IBatchWriteBuilder> items) =>
             new BatchWriteItemRequestBuilder(_context, new BatchItemsNode<IBatchWriteBuilder>(items, _node));
 
-        public Task ExecuteAsync(CancellationToken cancellationToken = default) => _context.BatchWriteItemAsync(_node ?? throw new DdbException("Can't execute empty batch write item request."), cancellationToken);
+        public IBatchWriteItemRequestBuilder WithReturnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity) =>
+            new BatchWriteItemRequestBuilder(_context, new ReturnConsumedCapacityNode(returnConsumedCapacity, _node));
+
+        public Task ExecuteAsync(CancellationToken cancellationToken = default) => 
+            _context.BatchWriteItemAsync(_node ?? throw new DdbException("Can't execute empty batch write item request."), cancellationToken);
+
+        public Task<BatchWriteItemResponse> ToResponseAsync(CancellationToken cancellationToken = default) =>
+            _context.BatchWriteItemResponseAsync(_node ?? throw new DdbException("Can't execute empty batch write item request."), cancellationToken);
     }
 }

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchWriteItemResponse.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/BatchWriteItemResponse.cs
@@ -20,7 +20,7 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
         /// </item>
         /// </list>
         /// </summary>
-        public IReadOnlyList<TableConsumedCapacity>? ConsumedCapacity { get; }
+        public IReadOnlyList<FullConsumedCapacity>? ConsumedCapacity { get; }
         
         public IReadOnlyDictionary<string, ItemCollectionMetrics>? ItemCollectionMetrics { get; }
         
@@ -29,7 +29,7 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
         /// </summary>
         public IReadOnlyDictionary<string, IReadOnlyList<BatchWriteOperation>>? UnprocessedItems { get; }
 
-        public BatchWriteItemResponse(IReadOnlyList<TableConsumedCapacity>? consumedCapacity, IReadOnlyDictionary<string, ItemCollectionMetrics>? itemCollectionMetrics, IReadOnlyDictionary<string, IReadOnlyList<BatchWriteOperation>>? unprocessedItems)
+        public BatchWriteItemResponse(IReadOnlyList<FullConsumedCapacity>? consumedCapacity, IReadOnlyDictionary<string, ItemCollectionMetrics>? itemCollectionMetrics, IReadOnlyDictionary<string, IReadOnlyList<BatchWriteOperation>>? unprocessedItems)
         {
             ConsumedCapacity = consumedCapacity;
             UnprocessedItems = unprocessedItems;

--- a/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchWriteItemRequestBuilder.cs
+++ b/src/EfficientDynamoDb/Operations/BatchWriteItem/IBatchWriteItemRequestBuilder.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using EfficientDynamoDb.Operations.Shared;
 
 namespace EfficientDynamoDb.Operations.BatchWriteItem
 {
@@ -15,6 +16,13 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
         /// <param name="cancellationToken">Token that can be used to cancel the task.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         Task ExecuteAsync(CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Executes the BatchWrite operation and returns the deserialized response.
+        /// </summary>
+        /// <param name="cancellationToken">Token that can be used to cancel the task.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task<BatchWriteItemResponse> ToResponseAsync(CancellationToken cancellationToken = default);
         
         /// <summary>
         /// Specify the write operations to perform in batch.
@@ -38,5 +46,12 @@ namespace EfficientDynamoDb.Operations.BatchWriteItem
         /// Use <see cref="Batch"/> static class to construct item builders.
         /// </remarks>
         IBatchWriteItemRequestBuilder WithItems(IEnumerable<IBatchWriteBuilder> items);
+        
+        /// <summary>
+        /// Specifies the consumed capacity details to include in the response.
+        /// </summary>
+        /// <param name="returnConsumedCapacity">The <see cref="ReturnConsumedCapacity"/> option.</param>
+        /// <returns>BatchGet operation builder.</returns>
+        IBatchWriteItemRequestBuilder WithReturnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity);
     }
 }

--- a/src/EfficientDynamoDb/Operations/DeleteItem/DeleteItemResponse.cs
+++ b/src/EfficientDynamoDb/Operations/DeleteItem/DeleteItemResponse.cs
@@ -46,7 +46,7 @@ namespace EfficientDynamoDb.Operations.DeleteItem
         /// <summary>
         /// The capacity units consumed by the <c>DeleteItem</c> operation. The data returned includes the total provisioned throughput consumed, along with statistics for the table and any indexes involved in the operation. <see cref="ConsumedCapacity"/> is only returned if the <see cref="DeleteItemRequest.ReturnConsumedCapacity"/> parameter was specified.
         /// </summary>
-        [DynamoDbProperty("Attributes")]
+        [DynamoDbProperty("ConsumedCapacity")]
         public FullConsumedCapacity? ConsumedCapacity { get; set; }
         
         // /// <summary>

--- a/src/EfficientDynamoDb/Operations/Shared/Capacity/FullConsumedCapacity.cs
+++ b/src/EfficientDynamoDb/Operations/Shared/Capacity/FullConsumedCapacity.cs
@@ -5,6 +5,7 @@ using EfficientDynamoDb.Internal.Converters.Primitives;
 
 namespace EfficientDynamoDb.Operations.Shared.Capacity
 {
+    [DynamoDbConverter(typeof(JsonObjectDdbConverter<FullConsumedCapacity>))]
     public class FullConsumedCapacity : ConsumedCapacity
     {
         [DynamoDbProperty("GlobalSecondaryIndexes", typeof(JsonIReadOnlyDictionaryDdbConverter<string, ConsumedCapacity>))]
@@ -13,6 +14,7 @@ namespace EfficientDynamoDb.Operations.Shared.Capacity
         [DynamoDbProperty("LocalSecondaryIndexes", typeof(JsonIReadOnlyDictionaryDdbConverter<string, ConsumedCapacity>))]
         public IReadOnlyDictionary<string, ConsumedCapacity>? LocalSecondaryIndexes { get; set; }
         
+        [DynamoDbProperty("Table", typeof(JsonObjectDdbConverter<ConsumedCapacity>))]
         public ConsumedCapacity? Table { get; set; }
 
         [DynamoDbProperty("TableName", typeof(StringDdbConverter))]

--- a/src/EfficientDynamoDb/Operations/Shared/Capacity/FullConsumedCapacity.cs
+++ b/src/EfficientDynamoDb/Operations/Shared/Capacity/FullConsumedCapacity.cs
@@ -12,6 +12,8 @@ namespace EfficientDynamoDb.Operations.Shared.Capacity
 
         [DynamoDbProperty("LocalSecondaryIndexes", typeof(JsonIReadOnlyDictionaryDdbConverter<string, ConsumedCapacity>))]
         public IReadOnlyDictionary<string, ConsumedCapacity>? LocalSecondaryIndexes { get; set; }
+        
+        public ConsumedCapacity? Table { get; set; }
 
         [DynamoDbProperty("TableName", typeof(StringDdbConverter))]
         public string? TableName { get; set; }

--- a/src/EfficientDynamoDb/Operations/TransactWriteItems/TransactWriteItemsResponse.cs
+++ b/src/EfficientDynamoDb/Operations/TransactWriteItems/TransactWriteItemsResponse.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using EfficientDynamoDb.Attributes;
+using EfficientDynamoDb.Internal.Converters.Json;
 using EfficientDynamoDb.Operations.Shared;
 using EfficientDynamoDb.Operations.Shared.Capacity;
 
@@ -10,14 +11,14 @@ namespace EfficientDynamoDb.Operations.TransactWriteItems
         /// <summary>
         /// The capacity units consumed by the entire <c>TransactWriteItems</c> operation. The values of the list are ordered according to the ordering of the <see cref="TransactWriteItemsRequest.TransactItems"/> request parameter.
         /// </summary>
-        public FullConsumedCapacity? ConsumedCapacity { get; }
+        public IReadOnlyList<FullConsumedCapacity>? ConsumedCapacity { get; }
         
         /// <summary>
         /// A list of tables that were processed by <c>TransactWriteItems</c> and, for each table, information about any item collections that were affected by individual <c>UpdateItem</c>, <c>PutItem</c>, or <c>DeleteItem</c> operations.
         /// </summary>
         public IReadOnlyDictionary<string, ItemCollectionMetrics>? ItemCollectionMetrics { get; }
 
-        public TransactWriteItemsResponse(FullConsumedCapacity? consumedCapacity, IReadOnlyDictionary<string, ItemCollectionMetrics>? itemCollectionMetrics)
+        public TransactWriteItemsResponse(IReadOnlyList<FullConsumedCapacity>? consumedCapacity, IReadOnlyDictionary<string, ItemCollectionMetrics>? itemCollectionMetrics)
         {
             ConsumedCapacity = consumedCapacity;
             ItemCollectionMetrics = itemCollectionMetrics;
@@ -29,8 +30,8 @@ namespace EfficientDynamoDb.Operations.TransactWriteItems
         /// <summary>
         /// The capacity units consumed by the entire <c>TransactWriteItems</c> operation. The values of the list are ordered according to the ordering of the <see cref="TransactWriteItemsRequest.TransactItems"/> request parameter.
         /// </summary>
-        [DynamoDbProperty("ConsumedCapacity")]
-        public FullConsumedCapacity? ConsumedCapacity { get; set; }
+        [DynamoDbProperty("ConsumedCapacity", typeof(JsonIReadOnlyListDdbConverter<FullConsumedCapacity>))]
+        public IReadOnlyList<FullConsumedCapacity>? ConsumedCapacity { get; set; }
         
         // /// <summary>
         // /// A list of tables that were processed by <c>TransactWriteItems</c> and, for each table, information about any item collections that were affected by individual <c>UpdateItem</c>, <c>PutItem</c>, or <c>DeleteItem</c> operations.


### PR DESCRIPTION
**Additions:**
1. Exposed consumed capacity high-level API for batch requests. Addresses #222.

**Bugfixes:**
1. `ConsumedCapacity` was not parsed at all for `DeleteItem` operation due to incorrect JSON name mapping.
2. `TransactWrite` returns a list of consumed capacities (one item per table) but the previous version mapped it to a single item. This is technically a breaking change because it changes public property. However, attempts to get consumed capacity data for `TransactWrite` always resulted in a crash, so this should not break any real users.
3. `Table` property in `FullConsumedCapacity` was not mapped from JSON in all operations. 