### PR TITLE
Upgrade .NET version and harmonize versions of referenced packages

### DIFF
--- a/EfficientDynamoDb.Tests/EfficientDynamoDb.Tests.csproj
+++ b/EfficientDynamoDb.Tests/EfficientDynamoDb.Tests.csproj
@@ -1,18 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;net8.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="JustMock" Version="2021.2.511.1" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-      <PackageReference Include="NUnit" Version="3.13.2" />
-      <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="JustMock" Version="2021.2.511.1"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4"/>
+    <PackageReference Include="NUnit" Version="3.13.2"/>
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\src\EfficientDynamoDb\EfficientDynamoDb.csproj" />
-    </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <PackageReference Include="JustMock" Version="2024.1.124.247"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
+    <PackageReference Include="NUnit" Version="3.13.2"/>
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\EfficientDynamoDb\EfficientDynamoDb.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/EfficientDynamoDb.Tests/EfficientDynamoDb.Tests.csproj
+++ b/EfficientDynamoDb.Tests/EfficientDynamoDb.Tests.csproj
@@ -1,17 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="JustMock" Version="2021.2.511.1"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4"/>
-    <PackageReference Include="NUnit" Version="3.13.2"/>
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0"/>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+  <ItemGroup>
     <PackageReference Include="JustMock" Version="2024.1.124.247"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
     <PackageReference Include="NUnit" Version="3.13.2"/>

--- a/EfficientDynamoDb.Tests/EfficientDynamoDb.Tests.csproj
+++ b/EfficientDynamoDb.Tests/EfficientDynamoDb.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="JustMock" Version="2024.1.124.247"/>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
-    <PackageReference Include="NUnit" Version="3.13.2"/>
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0"/>
-  </ItemGroup>
+    <ItemGroup>
+      <PackageReference Include="JustMock" Version="2024.1.124.247" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+      <PackageReference Include="NUnit" Version="3.13.2" />
+      <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\src\EfficientDynamoDb\EfficientDynamoDb.csproj"/>
-  </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\src\EfficientDynamoDb\EfficientDynamoDb.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/EfficientDynamoDb.Tests/Examples/DynamoDbContextExampleTests.cs
+++ b/EfficientDynamoDb.Tests/Examples/DynamoDbContextExampleTests.cs
@@ -19,13 +19,7 @@ namespace EfficientDynamoDb.Tests.Examples
 
             dbContext.Arrange(x => x.GetItem<object>()).Returns(builderMock);
 
-            builderMock.Arrange(x => x.WithPrimaryKey(Arg.AnyString)
-                .ToItemAsync(Arg.IsAny<CancellationToken>()))
-            #if NET6_0
-                .TaskResult(expectedResult);
-            #elif NET7_0_OR_GREATER
-                .ReturnsAsync(expectedResult);
-            #endif
+            builderMock.Arrange(x => x.WithPrimaryKey(Arg.AnyString).ToItemAsync(Arg.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
             
             var result = await dbContext.GetItem<object>().WithPrimaryKey("pk").ToItemAsync();
 

--- a/EfficientDynamoDb.Tests/Examples/DynamoDbContextExampleTests.cs
+++ b/EfficientDynamoDb.Tests/Examples/DynamoDbContextExampleTests.cs
@@ -18,8 +18,15 @@ namespace EfficientDynamoDb.Tests.Examples
             var builderMock = Mock.Create<IGetItemEntityRequestBuilder<object>>();
 
             dbContext.Arrange(x => x.GetItem<object>()).Returns(builderMock);
-            builderMock.Arrange(x => x.WithPrimaryKey(Arg.AnyString).ToItemAsync(Arg.IsAny<CancellationToken>())).TaskResult(expectedResult);
 
+            builderMock.Arrange(x => x.WithPrimaryKey(Arg.AnyString)
+                .ToItemAsync(Arg.IsAny<CancellationToken>()))
+            #if NET6_0
+                .TaskResult(expectedResult);
+            #elif NET7_0_OR_GREATER
+                .ReturnsAsync(expectedResult);
+            #endif
+            
             var result = await dbContext.GetItem<object>().WithPrimaryKey("pk").ToItemAsync();
 
             Assert.That(result, Is.EqualTo(expectedResult));

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -1,19 +1,29 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-    </PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net7.0;net8.0;net6.0</TargetFrameworks>
+  </PropertyGroup>
 
-    <ItemGroup>
-      <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.4.5" />
-      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-      <PackageReference Include="System.Text.Json" Version="5.0.0" />
-    </ItemGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\EfficientDynamoDb\EfficientDynamoDb.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.4.5"/>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
+    <PackageReference Include="System.Text.Json" Version="8.0.3"/>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3"/>
+    <PackageReference Include="System.Text.Json" Version="5.0.0"/>
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <ProjectReference Include="..\EfficientDynamoDb\EfficientDynamoDb.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -1,24 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
-  </PropertyGroup>
+    <PropertyGroup>
+      <OutputType>Exe</OutputType>
+      <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.4.5" />
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+      <PackageReference Include="System.Text.Json" Version="8.0.3" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.5.4.5"/>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.12"/>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
-    <PackageReference Include="System.Text.Json" Version="8.0.3"/>
-  </ItemGroup>
-
-
-  <ItemGroup>
-    <ProjectReference Include="..\EfficientDynamoDb\EfficientDynamoDb.csproj"/>
-  </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\EfficientDynamoDb\EfficientDynamoDb.csproj" />
+    </ItemGroup>
 
 </Project>

--- a/src/Benchmarks/Benchmarks.csproj
+++ b/src/Benchmarks/Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 
@@ -11,14 +11,9 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     <PackageReference Include="System.Text.Json" Version="8.0.3"/>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3"/>
-    <PackageReference Include="System.Text.Json" Version="5.0.0"/>
   </ItemGroup>
 
 

--- a/src/EfficientDynamoDb.Credentials.AWSSDK/EfficientDynamoDb.Credentials.AWSSDK.csproj
+++ b/src/EfficientDynamoDb.Credentials.AWSSDK/EfficientDynamoDb.Credentials.AWSSDK.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0;net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>
     <PackageIcon>logo.png</PackageIcon>
@@ -26,26 +26,15 @@
     <None Include="../../README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' And ('$(Platform)' != 'AnyCpu' And '$(Platform)' != 'arm64')">
-    <PackageReference Include="MinVer" Version="2.5.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="AWSSDK.Core" Version="3.7.0.13"/>
-    <PackageReference Include="EfficientDynamoDb" Version="0.9.2-alpha.0.4"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+  <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.7.303.28"/>
     <PackageReference Include="EfficientDynamoDb" Version="0.9.15"/>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+
+    <PackageReference Include="MinVer" Version="2.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/EfficientDynamoDb.Credentials.AWSSDK/EfficientDynamoDb.Credentials.AWSSDK.csproj
+++ b/src/EfficientDynamoDb.Credentials.AWSSDK/EfficientDynamoDb.Credentials.AWSSDK.csproj
@@ -1,43 +1,54 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>nullable</WarningsAsErrors>
-        <PackageIcon>logo.png</PackageIcon>
-        <PackageIconUrl>https://alloczero.github.io/EfficientDynamoDb/img/logo.png</PackageIconUrl>
-        <PackageProjectUrl>https://alloczero.github.io/EfficientDynamoDb/</PackageProjectUrl>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Title>AWS SDK credentials compatibility for EfficientDynamoDb</Title>
-        <Description>AWS SDK credentials compatibility package for EfficientDynamoDb</Description>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageTags>dynamodb,nosql,dotnet,c#,aws,credentials</PackageTags>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;net8.0;net6.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <PackageIcon>logo.png</PackageIcon>
+    <PackageIconUrl>https://alloczero.github.io/EfficientDynamoDb/img/logo.png</PackageIconUrl>
+    <PackageProjectUrl>https://alloczero.github.io/EfficientDynamoDb/</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Title>AWS SDK credentials compatibility for EfficientDynamoDb</Title>
+    <Description>AWS SDK credentials compatibility package for EfficientDynamoDb</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageTags>dynamodb,nosql,dotnet,c#,aws,credentials</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
 
-    <PropertyGroup>
-        <MinVerTagPrefix>creds-awssdk-v</MinVerTagPrefix>
-    </PropertyGroup>
+  <PropertyGroup>
+    <MinVerTagPrefix>creds-awssdk-v</MinVerTagPrefix>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <None Include="../../website/static/img/logo.png" Pack="true" PackagePath="\" />
-    </ItemGroup>
+  <ItemGroup>
+    <None Include="../../website/static/img/logo.png" Pack="true" PackagePath="\"/>
+    <None Include="../../README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="AWSSDK.Core" Version="3.7.0.13" />
-      <PackageReference Include="EfficientDynamoDb" Version="0.9.2-alpha.0.4" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="MinVer" Version="2.5.0">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' And ('$(Platform)' != 'AnyCpu' And '$(Platform)' != 'arm64')">
+    <PackageReference Include="MinVer" Version="2.5.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-      <None Include="../../README.md" Pack="true" PackagePath="\" />  
-    </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="AWSSDK.Core" Version="3.7.0.13"/>
+    <PackageReference Include="EfficientDynamoDb" Version="0.9.2-alpha.0.4"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <PackageReference Include="AWSSDK.Core" Version="3.7.303.28"/>
+    <PackageReference Include="EfficientDynamoDb" Version="0.9.15"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/src/EfficientDynamoDb.Credentials.AWSSDK/EfficientDynamoDb.Credentials.AWSSDK.csproj
+++ b/src/EfficientDynamoDb.Credentials.AWSSDK/EfficientDynamoDb.Credentials.AWSSDK.csproj
@@ -1,43 +1,43 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
-    <PackageIcon>logo.png</PackageIcon>
-    <PackageIconUrl>https://alloczero.github.io/EfficientDynamoDb/img/logo.png</PackageIconUrl>
-    <PackageProjectUrl>https://alloczero.github.io/EfficientDynamoDb/</PackageProjectUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Title>AWS SDK credentials compatibility for EfficientDynamoDb</Title>
-    <Description>AWS SDK credentials compatibility package for EfficientDynamoDb</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageTags>dynamodb,nosql,dotnet,c#,aws,credentials</PackageTags>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <WarningsAsErrors>nullable</WarningsAsErrors>
+        <PackageIcon>logo.png</PackageIcon>
+        <PackageIconUrl>https://alloczero.github.io/EfficientDynamoDb/img/logo.png</PackageIconUrl>
+        <PackageProjectUrl>https://alloczero.github.io/EfficientDynamoDb/</PackageProjectUrl>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <Title>AWS SDK credentials compatibility for EfficientDynamoDb</Title>
+        <Description>AWS SDK credentials compatibility package for EfficientDynamoDb</Description>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageTags>dynamodb,nosql,dotnet,c#,aws,credentials</PackageTags>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <MinVerTagPrefix>creds-awssdk-v</MinVerTagPrefix>
-  </PropertyGroup>
+    <PropertyGroup>
+        <MinVerTagPrefix>creds-awssdk-v</MinVerTagPrefix>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="../../website/static/img/logo.png" Pack="true" PackagePath="\"/>
-    <None Include="../../README.md" Pack="true" PackagePath="\"/>
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="../../website/static/img/logo.png" Pack="true" PackagePath="\" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.303.28"/>
-    <PackageReference Include="EfficientDynamoDb" Version="0.9.15"/>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <ItemGroup>
+      <PackageReference Include="AWSSDK.Core" Version="3.7.303.28" />
+      <PackageReference Include="EfficientDynamoDb" Version="0.9.15" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="MinVer" Version="2.5.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
 
-    <PackageReference Include="MinVer" Version="2.5.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
+      <None Include="../../README.md" Pack="true" PackagePath="\" />  
+    </ItemGroup>
 
 </Project>

--- a/src/EfficientDynamoDb/Converters/DdbConverter.cs
+++ b/src/EfficientDynamoDb/Converters/DdbConverter.cs
@@ -154,10 +154,8 @@ namespace EfficientDynamoDb.Converters
 
             var originalSpan = new ReadOnlySpan<byte>(reader.State.Buffer, reader.State.BufferStart, reader.State.BufferLength);
             var offset = checked((int) initialReaderBytesConsumed);
-            reader = new DdbReader(originalSpan.Slice(offset),
-                reader.JsonReaderValue.IsFinalBlock,
-                ref initialReaderState, ref reader.State);
-
+            var span = originalSpan[offset..];
+            reader = new DdbReader(span, reader.JsonReaderValue.IsFinalBlock, initialReaderState, reader.State);
             reader.State.BufferStart += offset;
             reader.State.BufferLength -= offset;
 

--- a/src/EfficientDynamoDb/Converters/DdbReader.cs
+++ b/src/EfficientDynamoDb/Converters/DdbReader.cs
@@ -20,7 +20,13 @@ namespace EfficientDynamoDb.Converters
 
         public AttributeType AttributeType => State.GetCurrent().AttributeType;
 
-        internal DdbReader(in ReadOnlySpan<byte> buffer, bool isFinalBlock, ref JsonReaderState readerState, ref DdbEntityReadStack readStack)
+        internal DdbReader(ReadOnlySpan<byte> buffer, bool isFinalBlock, ref JsonReaderState readerState, ref DdbEntityReadStack readStack)
+        {
+            JsonReaderValue = new Utf8JsonReader(buffer, isFinalBlock, readerState);
+            State = readStack;
+        }
+        
+        internal DdbReader(ReadOnlySpan<byte> buffer, bool isFinalBlock, JsonReaderState readerState, DdbEntityReadStack readStack)
         {
             JsonReaderValue = new Utf8JsonReader(buffer, isFinalBlock, readerState);
             State = readStack;

--- a/src/EfficientDynamoDb/DynamoDbContextMetadata.cs
+++ b/src/EfficientDynamoDb/DynamoDbContextMetadata.cs
@@ -118,7 +118,7 @@ namespace EfficientDynamoDb
                 return converter;
             
             var nullableConverterType = typeof(NullableValueTypeDdbConverter<>).MakeGenericType(type);
-            return (DdbConverter) Activator.CreateInstance(nullableConverterType, converter);
+            return Activator.CreateInstance(nullableConverterType, converter) as DdbConverter ?? throw new DdbException("Can't create nullable value type converter.");
         }
 
         private DdbConverter GetOrAddNestedObjectConverter(Type propertyType)

--- a/src/EfficientDynamoDb/EfficientDynamoDb.csproj
+++ b/src/EfficientDynamoDb/EfficientDynamoDb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>net7.0;net8.0;net6.0</TargetFrameworks>
+      <TargetFramework>net8.0</TargetFramework>
       <Nullable>enable</Nullable>
       <WarningsAsErrors>nullable</WarningsAsErrors>
       <PackageIcon>logo.png</PackageIcon>
@@ -33,26 +33,7 @@
       <None Include="../../README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' And ('$(Platform)' != 'AnyCpu' And '$(Platform)' != 'arm64')">
-      <PackageReference Include="MinVer" Version="2.5.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-      <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.6"/>
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-
-      <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-      <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0"/>
-      <PackageReference Include="System.Text.Json" Version="5.0.0"/>
-    </ItemGroup>
-
-    <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <ItemGroup>
         <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0"/>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
             <PrivateAssets>all</PrivateAssets>
@@ -61,6 +42,11 @@
         <PackageReference Include="System.Net.Http" Version="4.3.4"/>
         <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0"/>
         <PackageReference Include="System.Text.Json" Version="8.0.3"/>
+
+        <PackageReference Include="MinVer" Version="2.5.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EfficientDynamoDb/EfficientDynamoDb.csproj
+++ b/src/EfficientDynamoDb/EfficientDynamoDb.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
-        <Nullable>enable</Nullable>
-        <WarningsAsErrors>nullable</WarningsAsErrors>
-        <PackageIcon>logo.png</PackageIcon>
-        <PackageIconUrl>https://alloczero.github.io/EfficientDynamoDb/img/logo.png</PackageIconUrl>
-        <PackageProjectUrl>https://alloczero.github.io/EfficientDynamoDb/</PackageProjectUrl>
-        <PackageReadmeFile>README.md</PackageReadmeFile>
-        <Title>High performance DynamoDB library</Title>
-        <Description>High-performance DynamoDb library with a significant focus on efficient resources utilization.</Description>
-        <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageTags>dynamodb,nosql,aws,dotnet,c#</PackageTags>
-        <PublishRepositoryUrl>true</PublishRepositoryUrl>
-        <IncludeSymbols>true</IncludeSymbols>
-        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+      <TargetFrameworks>net7.0;net8.0;net6.0</TargetFrameworks>
+      <Nullable>enable</Nullable>
+      <WarningsAsErrors>nullable</WarningsAsErrors>
+      <PackageIcon>logo.png</PackageIcon>
+      <PackageIconUrl>https://alloczero.github.io/EfficientDynamoDb/img/logo.png</PackageIconUrl>
+      <PackageProjectUrl>https://alloczero.github.io/EfficientDynamoDb/</PackageProjectUrl>
+      <PackageReadmeFile>README.md</PackageReadmeFile>
+      <Title>High performance DynamoDB library</Title>
+      <Description>High-performance DynamoDb library with a significant focus on efficient resources utilization.</Description>
+      <PackageLicenseExpression>MIT</PackageLicenseExpression>
+      <PackageTags>dynamodb,nosql,aws,dotnet,c#</PackageTags>
+      <PublishRepositoryUrl>true</PublishRepositoryUrl>
+      <IncludeSymbols>true</IncludeSymbols>
+      <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -26,28 +26,45 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <MinVerTagPrefix>effddb-v</MinVerTagPrefix>
+      <MinVerTagPrefix>effddb-v</MinVerTagPrefix>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.6" />
-      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="MinVer" Version="2.5.0">
-        <PrivateAssets>all</PrivateAssets>
-        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="System.Net.Http" Version="4.3.4" />
-      <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
-      <PackageReference Include="System.Text.Json" Version="5.0.0" />
+      <None Include="../../README.md" Pack="true" PackagePath="\"/>
+    </ItemGroup>
 
-      <None Include="../../README.md" Pack="true" PackagePath="\" />  
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0' And ('$(Platform)' != 'AnyCpu' And '$(Platform)' != 'arm64')">
+      <PackageReference Include="MinVer" Version="2.5.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+      <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.6"/>
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+
+      <PackageReference Include="System.Net.Http" Version="4.3.4"/>
+      <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0"/>
+      <PackageReference Include="System.Text.Json" Version="5.0.0"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="System.Net.Http" Version="4.3.4"/>
+        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0"/>
+        <PackageReference Include="System.Text.Json" Version="8.0.3"/>
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="../../website/static/img/logo.png" Pack="true" PackagePath="\" />
+        <None Include="../../website/static/img/logo.png" Pack="true" PackagePath="\"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EfficientDynamoDb/EfficientDynamoDb.csproj
+++ b/src/EfficientDynamoDb/EfficientDynamoDb.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFramework>net8.0</TargetFramework>
-      <Nullable>enable</Nullable>
-      <WarningsAsErrors>nullable</WarningsAsErrors>
-      <PackageIcon>logo.png</PackageIcon>
-      <PackageIconUrl>https://alloczero.github.io/EfficientDynamoDb/img/logo.png</PackageIconUrl>
-      <PackageProjectUrl>https://alloczero.github.io/EfficientDynamoDb/</PackageProjectUrl>
-      <PackageReadmeFile>README.md</PackageReadmeFile>
-      <Title>High performance DynamoDB library</Title>
-      <Description>High-performance DynamoDb library with a significant focus on efficient resources utilization.</Description>
-      <PackageLicenseExpression>MIT</PackageLicenseExpression>
-      <PackageTags>dynamodb,nosql,aws,dotnet,c#</PackageTags>
-      <PublishRepositoryUrl>true</PublishRepositoryUrl>
-      <IncludeSymbols>true</IncludeSymbols>
-      <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <WarningsAsErrors>nullable</WarningsAsErrors>
+        <PackageIcon>logo.png</PackageIcon>
+        <PackageIconUrl>https://alloczero.github.io/EfficientDynamoDb/img/logo.png</PackageIconUrl>
+        <PackageProjectUrl>https://alloczero.github.io/EfficientDynamoDb/</PackageProjectUrl>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
+        <Title>High performance DynamoDB library</Title>
+        <Description>High-performance DynamoDb library with a significant focus on efficient resources utilization.</Description>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageTags>dynamodb,nosql,aws,dotnet,c#</PackageTags>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -26,31 +26,28 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <MinVerTagPrefix>effddb-v</MinVerTagPrefix>
+        <MinVerTagPrefix>effddb-v</MinVerTagPrefix>
     </PropertyGroup>
 
     <ItemGroup>
-      <None Include="../../README.md" Pack="true" PackagePath="\"/>
+      <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="MinVer" Version="2.5.0">
+        <PrivateAssets>all</PrivateAssets>
+        <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="System.Net.Http" Version="4.3.4" />
+      <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
+      <PackageReference Include="System.Text.Json" Version="8.0.3" />
+
+      <None Include="../../README.md" Pack="true" PackagePath="\" />  
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.0"/>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="System.Net.Http" Version="4.3.4"/>
-        <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0"/>
-        <PackageReference Include="System.Text.Json" Version="8.0.3"/>
-
-        <PackageReference Include="MinVer" Version="2.5.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <ItemGroup>
-        <None Include="../../website/static/img/logo.png" Pack="true" PackagePath="\"/>
+        <None Include="../../website/static/img/logo.png" Pack="true" PackagePath="\" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/EfficientDynamoDb/Exceptions/AccessDeniedException.cs
+++ b/src/EfficientDynamoDb/Exceptions/AccessDeniedException.cs
@@ -9,10 +9,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class AccessDeniedException : DdbException
     {
-        public AccessDeniedException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
-
         public AccessDeniedException(string message) : base(message)
         {
         }

--- a/src/EfficientDynamoDb/Exceptions/ChecksumMismatchException.cs
+++ b/src/EfficientDynamoDb/Exceptions/ChecksumMismatchException.cs
@@ -7,9 +7,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class ChecksumMismatchException : DdbException
     {
-        public ChecksumMismatchException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public ChecksumMismatchException() : base("Dynamodb x-amz-crc32 header value does not match the CRC32 value of the response body.")
         {

--- a/src/EfficientDynamoDb/Exceptions/ConditionalCheckFailedException.cs
+++ b/src/EfficientDynamoDb/Exceptions/ConditionalCheckFailedException.cs
@@ -12,10 +12,6 @@ namespace EfficientDynamoDb.Exceptions
     public class ConditionalCheckFailedException : DdbException
     {
         public Document? Item { get; }
-        
-        public ConditionalCheckFailedException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public ConditionalCheckFailedException(Document? item, string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/DdbException.cs
+++ b/src/EfficientDynamoDb/Exceptions/DdbException.cs
@@ -8,9 +8,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class DdbException : Exception
     {
-        public DdbException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public DdbException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/IdempotentParameterMismatchException.cs
+++ b/src/EfficientDynamoDb/Exceptions/IdempotentParameterMismatchException.cs
@@ -8,9 +8,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class IdempotentParameterMismatchException : DdbException
     {
-        public IdempotentParameterMismatchException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public IdempotentParameterMismatchException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/IncompleteSignatureException.cs
+++ b/src/EfficientDynamoDb/Exceptions/IncompleteSignatureException.cs
@@ -9,9 +9,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class IncompleteSignatureException : DdbException
     {
-        public IncompleteSignatureException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public IncompleteSignatureException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/InternalServerErrorException.cs
+++ b/src/EfficientDynamoDb/Exceptions/InternalServerErrorException.cs
@@ -9,9 +9,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class InternalServerErrorException : RetryableException
     {
-        public InternalServerErrorException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public InternalServerErrorException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/ItemCollectionSizeLimitExceededException.cs
+++ b/src/EfficientDynamoDb/Exceptions/ItemCollectionSizeLimitExceededException.cs
@@ -9,9 +9,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class ItemCollectionSizeLimitExceededException : DdbException
     {
-        public ItemCollectionSizeLimitExceededException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public ItemCollectionSizeLimitExceededException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/LimitExceededException.cs
+++ b/src/EfficientDynamoDb/Exceptions/LimitExceededException.cs
@@ -9,9 +9,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class LimitExceededException : RetryableException
     {
-        public LimitExceededException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public LimitExceededException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/MissingAuthenticationTokenException.cs
+++ b/src/EfficientDynamoDb/Exceptions/MissingAuthenticationTokenException.cs
@@ -9,9 +9,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class MissingAuthenticationTokenException : DdbException
     {
-        public MissingAuthenticationTokenException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public MissingAuthenticationTokenException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/ProvisionedThroughputExceededException.cs
+++ b/src/EfficientDynamoDb/Exceptions/ProvisionedThroughputExceededException.cs
@@ -9,9 +9,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class ProvisionedThroughputExceededException : RetryableException
     {
-        public ProvisionedThroughputExceededException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public ProvisionedThroughputExceededException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/RequestLimitExceededException.cs
+++ b/src/EfficientDynamoDb/Exceptions/RequestLimitExceededException.cs
@@ -10,9 +10,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class RequestLimitExceededException : RetryableException
     {
-        public RequestLimitExceededException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public RequestLimitExceededException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/ResourceInUseException.cs
+++ b/src/EfficientDynamoDb/Exceptions/ResourceInUseException.cs
@@ -10,9 +10,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class ResourceInUseException : DdbException
     {
-        public ResourceInUseException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public ResourceInUseException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/ResourceNotFoundException.cs
+++ b/src/EfficientDynamoDb/Exceptions/ResourceNotFoundException.cs
@@ -10,9 +10,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class ResourceNotFoundException : DdbException
     {
-        public ResourceNotFoundException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public ResourceNotFoundException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/RetryableException.cs
+++ b/src/EfficientDynamoDb/Exceptions/RetryableException.cs
@@ -5,9 +5,6 @@ namespace EfficientDynamoDb.Exceptions
 {
     public class RetryableException : DdbException
     {
-        public RetryableException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public RetryableException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/ServiceUnavailableException.cs
+++ b/src/EfficientDynamoDb/Exceptions/ServiceUnavailableException.cs
@@ -9,9 +9,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class ServiceUnavailableException : RetryableException
     {
-        public ServiceUnavailableException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public ServiceUnavailableException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/ThrottlingException.cs
+++ b/src/EfficientDynamoDb/Exceptions/ThrottlingException.cs
@@ -10,9 +10,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class ThrottlingException : RetryableException
     {
-        public ThrottlingException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public ThrottlingException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/TransactionInProgressException.cs
+++ b/src/EfficientDynamoDb/Exceptions/TransactionInProgressException.cs
@@ -8,9 +8,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class TransactionInProgressException : DdbException
     {
-        public TransactionInProgressException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public TransactionInProgressException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/UnrecognizedClientException.cs
+++ b/src/EfficientDynamoDb/Exceptions/UnrecognizedClientException.cs
@@ -9,9 +9,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class UnrecognizedClientException : DdbException
     {
-        public UnrecognizedClientException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public UnrecognizedClientException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Exceptions/ValidationException.cs
+++ b/src/EfficientDynamoDb/Exceptions/ValidationException.cs
@@ -9,9 +9,6 @@ namespace EfficientDynamoDb.Exceptions
     /// </summary>
     public class ValidationException : DdbException
     {
-        public ValidationException(SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-        }
 
         public ValidationException(string message) : base(message)
         {

--- a/src/EfficientDynamoDb/Internal/Core/Utilities/ThreadSafeRandom.cs
+++ b/src/EfficientDynamoDb/Internal/Core/Utilities/ThreadSafeRandom.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Threading;
 
 namespace EfficientDynamoDb.Internal.Core.Utilities
@@ -10,6 +11,10 @@ namespace EfficientDynamoDb.Internal.Core.Utilities
 
         public static readonly ThreadSafeRandom Instance = new ThreadSafeRandom();
 
-        public int Next(int maxValue) => Random.Value.Next(maxValue);
+        public int Next(int maxValue)
+        {
+            Debug.Assert(Random.Value != null, (string?)"Random.Value != null");
+            return Random.Value.Next(maxValue);
+        }
     }
 }

--- a/src/EfficientDynamoDb/Internal/Signing/Utils/UrlEncoder.cs
+++ b/src/EfficientDynamoDb/Internal/Signing/Utils/UrlEncoder.cs
@@ -64,7 +64,7 @@ namespace EfficientDynamoDb.Internal.Signing.Utils
             var stringBuilder = new StringBuilder();
             foreach (var ch in "/:'()!*[]$")
             {
-                var str = Uri.EscapeUriString(ch.ToString());
+                var str = Uri.EscapeDataString(ch.ToString());
                 if (str.Length == 1 && str[0] == ch)
                     stringBuilder.Append(ch);
             }


### PR DESCRIPTION
This commit makes several changes to the .NET projects and their dependencies. The main changes include upgrading the projects to target newer versions of .NET (.NET 6.0, 7.0 and 8.0), and harmonize versions of referenced packages.

The package versions are now based on the target framework. The git diff shows the removal and addition of PackageReference tags that ensure packages have different versions based on the targeted framework. For example, `Microsoft.NET.Test.Sdk` is upgraded from 16.9.4 to 17.9.0 if the target framework is not net6.0.

In addition, the commit modifies the projects to produce an executable as the output type instead of a class library and removes constructors in exception classes which are obsolete from .net8 onwards (https://github.com/dotnet/docs/issues/34893).

Finally, some refactoring is done to comply with the latest .net requirements regarding value and ref types.

Overall, this commit ensures the projects align with the latest .NET platform, benefiting from performance improvements and other advancements, while keeping the project dependencies clean and consistent.

## Benchmark 

### .net7.0 
```
BenchmarkDotNet v0.13.12, macOS Sonoma 14.3.1 (23D60) [Darwin 23.3.0]
Apple M1 Pro, 1 CPU, 10 logical and 10 physical cores
.NET SDK 8.0.201
  [Host]     : .NET 7.0.16 (7.0.1624.6629), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 7.0.16 (7.0.1624.6629), Arm64 RyuJIT AdvSIMD


| Method            | EntitiesCount | Mean         | Error      | StdDev     | Gen0      | Gen1      | Gen2     | Allocated   |
|------------------ |-------------- |-------------:|-----------:|-----------:|----------:|----------:|---------:|------------:|
| EfficientDynamoDb | 10            |     33.07 us |   0.384 us |   0.359 us |    2.8076 |         - |        - |    17.23 KB |
| aws-sdk-net       | 10            |    309.88 us |   2.384 us |   2.113 us |   51.2695 |   13.1836 |        - |   315.54 KB |
| EfficientDynamoDb | 100           |    247.07 us |   3.939 us |   3.684 us |   19.5313 |    3.9063 |        - |   119.89 KB |
| aws-sdk-net       | 100           |  3,334.25 us |  47.241 us |  41.878 us |  480.4688 |  210.9375 |        - |  2958.24 KB |
| EfficientDynamoDb | 1000          |  2,468.43 us |  16.851 us |  15.762 us |  183.5938 |   89.8438 |        - |  1146.49 KB |
| aws-sdk-net       | 1000          | 48,140.56 us | 700.329 us | 620.823 us | 5090.9091 | 1363.6364 | 454.5455 | 29379.18 KB |
```

## .net8.0
```
BenchmarkDotNet v0.13.12, macOS Sonoma 14.3.1 (23D60) [Darwin 23.3.0]
Apple M1 Pro, 1 CPU, 10 logical and 10 physical cores
.NET SDK 8.0.201
  [Host]     : .NET 8.0.2 (8.0.224.6711), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.2 (8.0.224.6711), Arm64 RyuJIT AdvSIMD


| Method            | EntitiesCount | Mean         | Error      | StdDev     | Gen0      | Gen1      | Gen2      | Allocated   |
|------------------ |-------------- |-------------:|-----------:|-----------:|----------:|----------:|----------:|------------:|
| EfficientDynamoDb | 10            |     25.87 us |   0.252 us |   0.211 us |    2.7771 |    0.0916 |         - |    17.17 KB |
| aws-sdk-net       | 10            |    207.30 us |   3.084 us |   2.885 us |   51.2695 |   13.1836 |         - |   314.92 KB |
| EfficientDynamoDb | 100           |    187.08 us |   1.162 us |   1.030 us |   19.5313 |    0.2441 |         - |   119.84 KB |
| aws-sdk-net       | 100           |  2,459.85 us |  48.444 us | 119.743 us |  476.5625 |  234.3750 |         - |  2956.09 KB |
| EfficientDynamoDb | 1000          |  2,107.96 us |  41.388 us |  66.833 us |  183.5938 |   89.8438 |         - |  1146.55 KB |
| aws-sdk-net       | 1000          | 40,097.83 us | 494.365 us | 412.817 us | 4833.3333 | 1250.0000 | 1083.3333 | 29341.09 KB |
```

# Note:
I don't have available a proper x86 setup where I could run the benchmark for the older dotnet versions, so I can't provide a proper comparison between current .netstandard2.1 and latest .net8. The improvement is still in line with the comparison against aws sdk, which also sees improvements by bumping the framework. So I see an overall performance gain. 

If anyone is able to, can you please run the benchmarks on your system to see how it compares against the current version used? thank you :) 