### PR TITLE
Adding [CallerMemberName] to 3 new overloads for the DynamoDbPropertyAttribute

### DIFF
--- a/src/EfficientDynamoDb/Attributes/DynamoDbPropertyAttribute.cs
+++ b/src/EfficientDynamoDb/Attributes/DynamoDbPropertyAttribute.cs
@@ -23,6 +23,18 @@ namespace EfficientDynamoDb.Attributes
         {
         }
 
+        public DynamoDbPropertyAttribute(Type? ddbConverterType, [CallerMemberName] string name = default!) : this(name, ddbConverterType, DynamoDbAttributeType.Regular)
+        {
+        }
+        
+        public DynamoDbPropertyAttribute(DynamoDbAttributeType attributeType, [CallerMemberName] string name = default!) : this(name, null, attributeType)
+        {
+        }
+
+        public DynamoDbPropertyAttribute(Type? ddbConverterType, DynamoDbAttributeType attributeType, [CallerMemberName] string name = default!) : this(name, ddbConverterType, attributeType)
+        {
+        }
+
         public DynamoDbPropertyAttribute(string name, Type? ddbConverterType, DynamoDbAttributeType attributeType)
         {
             Name = name;


### PR DESCRIPTION
This does not use runtime reflection, and allows for a simpler definition without having to define the property name manually if the user doesn't want to

Solves https://github.com/AllocZero/EfficientDynamoDb/issues/239