### PR TITLE
Use interface attributes

### DIFF
--- a/src/Benchmarks/Benchmarks/Query/QueryEntityComparisonBenchmark.cs
+++ b/src/Benchmarks/Benchmarks/Query/QueryEntityComparisonBenchmark.cs
@@ -51,6 +51,9 @@ namespace Benchmarks.Query
             });
         }
         
+        [GlobalSetup(Target = nameof(EfficientDynamoDbFromInterfaceBenchmark))]
+        public void SetupMixedFromInterfaceBenchmark() => SetupBenchmark<MixedEntityFromInterface>(x => EntitiesFactory.CreateMixedEntityFromInterface(x).ToDocument());
+
         [GlobalSetup]
         public void SetupMixedBenchmark() => SetupBenchmark<MixedEntity>(x => EntitiesFactory.CreateMixedEntity(x).ToDocument());
 
@@ -59,6 +62,16 @@ namespace Benchmarks.Query
         {
             var result = await _efficientDbContext.Query<MixedEntity>()
                 .WithKeyExpression(Condition<MixedEntity>.On(x => x.Pk).EqualTo("test"))
+                .ToListAsync().ConfigureAwait(false);
+
+            return result.Count;
+        }
+        
+        [Benchmark(Description = "EfficientDynamoDb-FromInterface")]
+        public async Task<int> EfficientDynamoDbFromInterfaceBenchmark()
+        {
+            var result = await _efficientDbContext.Query<MixedEntityFromInterface>()
+                .WithKeyExpression(Condition<MixedEntityFromInterface>.On(x => x.Pk).EqualTo("test"))
                 .ToListAsync().ConfigureAwait(false);
 
             return result.Count;

--- a/src/Benchmarks/Entities/MixedEntityFromInterface.cs
+++ b/src/Benchmarks/Entities/MixedEntityFromInterface.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using Amazon.DynamoDBv2.DataModel;
+
+namespace Benchmarks.Entities
+{
+    public interface IMixedEntityFromInterface
+    {
+        [EfficientDynamoDb.Attributes.DynamoDbProperty("m")]
+        MapObject M { get; set; }
+
+        [EfficientDynamoDb.Attributes.DynamoDbProperty("l1")]
+        List<MapObject> L1 { get; set; }
+
+        [EfficientDynamoDb.Attributes.DynamoDbProperty("l2")]
+        List<MapObject> L2 { get; set; }
+
+        [EfficientDynamoDb.Attributes.DynamoDbProperty("l3")]
+        List<MapObject> L3 { get; set; }
+
+        [EfficientDynamoDb.Attributes.DynamoDbProperty("ss")]
+        HashSet<string> Ss { get; set; }
+
+        [EfficientDynamoDb.Attributes.DynamoDbProperty("ns")]
+        HashSet<int> Ns { get; set; }
+
+        [EfficientDynamoDb.Attributes.DynamoDbProperty("s")]
+        string S { get; set; }
+
+        [EfficientDynamoDb.Attributes.DynamoDbProperty("n")]
+        int N { get; set; }
+
+        [EfficientDynamoDb.Attributes.DynamoDbProperty("b")]
+        bool B { get; set; }
+
+    }
+
+    public class MixedEntityFromInterface : KeysOnlyEntity, IMixedEntityFromInterface
+    {
+        [DynamoDBProperty("m")] 
+        public MapObject M { get; set; }
+
+        [DynamoDBProperty("l1")] 
+        public List<MapObject> L1 { get; set; }
+        
+        [DynamoDBProperty("l2")] 
+        public List<MapObject> L2 { get; set; }
+        
+        [DynamoDBProperty("l3")] 
+        public List<MapObject> L3 { get; set; }
+
+        [DynamoDBProperty("ss")] 
+        public HashSet<string> Ss { get; set; }
+
+        [DynamoDBProperty("ns")] 
+        public HashSet<int> Ns { get; set; }
+
+        [DynamoDBProperty("s")]
+        public string S { get; set; }
+        
+        [DynamoDBProperty("n")]
+        public int N { get; set; }
+
+        [DynamoDBProperty("b")] 
+        public bool B { get; set; }
+    }
+}

--- a/src/Benchmarks/Mocks/EntitiesFactory.cs
+++ b/src/Benchmarks/Mocks/EntitiesFactory.cs
@@ -78,6 +78,24 @@ namespace Benchmarks.Mocks
             };
         }
         
+        public static MixedEntityFromInterface CreateMixedEntityFromInterface(int index)
+        {
+            return new MixedEntityFromInterface
+            {
+                Pk = $"pk_{index:0000}",
+                Sk = $"sk_{index:0000}",
+                B = index % 2 == 0,
+                N = index,
+                S = $"test_{index:0000}",
+                Ns = new HashSet<int> {index},
+                Ss = new HashSet<string> {$"test_set_{index:0000}"},
+                M = new MapObject {P1 = $"test_p0_{index:0000}"},
+                L1 = new List<MapObject> {new MapObject {P1 = $"test_p1_{index:0000}"}},
+                L2 = new List<MapObject> {new MapObject {P1 = $"test_p2_{index:0000}"}},
+                L3 = new List<MapObject> {new MapObject {P1 = $"test_p3_{index:0000}"}}
+            };
+        }
+        
         public static LargeStringFieldsEntity CreateLargeStringEntity(int index)
         {
             return new LargeStringFieldsEntity

--- a/src/EfficientDynamoDb/Internal/Metadata/DdbClassInfo.cs
+++ b/src/EfficientDynamoDb/Internal/Metadata/DdbClassInfo.cs
@@ -51,13 +51,18 @@ namespace EfficientDynamoDb.Internal.Metadata
             ConverterBase = converter;
             ConverterType = converter.GetType();
             ClassType = ConverterBase.ClassType;
+            var typeInterfaces = new Stack<Type>(type.GetInterfaces());
 
             switch (ClassType)
             {
                 case DdbClassType.Object:
                 {
-                    for (var currentType = type; currentType != null; currentType = currentType.BaseType)
+                    for (var currentType = type; currentType != null || typeInterfaces.Count > 0; currentType = currentType?.BaseType)
                     {
+                        if (currentType?.BaseType == null && typeInterfaces.Count <= 0)
+                            continue;
+                        
+                        currentType ??= typeInterfaces.Pop();
                         const BindingFlags bindingFlags =
                             BindingFlags.Instance |
                             BindingFlags.Public |


### PR DESCRIPTION
This PR brings support to defining DynamoDb attributes on the interfaces instead of only classes. This doesn't happen by default on C# as attributes on interfaces are not projected to the classes that implement them. However, through some reflection we can get that information. 

## Example 

```csharp

public interface IDynamoEntity
{
    [DynamoDbProperty("UserId")]
    string UserId { get; set; }
}

internal class UserEntity : IDynamoEntity
{
    // This is already known as a property because the interface defined it as attribute.
    public string UserId { get; set; }

    [DynamoDbProperty("Email")
    public string Email { get; set; }
}

internal class PermissionsEntity : IDynamoEntity
{
    // This is already known as a property because the interface defined it as attribute.
    public string UserId { get; set; } 

    [DynamoDbProperty("IsAdmin")]
    public bool IsAdmin { get; set; }
}

```

## Performance

However, **I need somebody that knows how to use properly benchmarkdotnet to validate the results**. I added a test case and I have no explanation for the numbers. I ran this many times and this implementation is somehow more performant... I honestly don't know how or why. 

```
BenchmarkDotNet v0.13.12, macOS Sonoma 14.3.1 (23D60) [Darwin 23.3.0]
Apple M1 Pro, 1 CPU, 10 logical and 10 physical cores
.NET SDK 8.0.201
  [Host]     : .NET 8.0.2 (8.0.224.6711), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.2 (8.0.224.6711), Arm64 RyuJIT AdvSIMD


| Method                          | EntitiesCount | Mean         | Error      | StdDev       | Gen0      | Gen1      | Gen2      | Allocated   |
|-------------------------------- |-------------- |-------------:|-----------:|-------------:|----------:|----------:|----------:|------------:|
| EfficientDynamoDb               | 10            |     26.44 us |   0.431 us |     0.382 us |    2.7466 |    0.0610 |         - |    17.17 KB |
| EfficientDynamoDb-FromInterface | 10            |     18.75 us |   1.560 us |     4.525 us |    1.2207 |         - |         - |     7.56 KB |
| aws-sdk-net                     | 10            |    205.65 us |   4.073 us |     8.768 us |   51.2695 |   13.1836 |         - |   314.92 KB |
| EfficientDynamoDb               | 100           |    215.11 us |   3.996 us |     3.925 us |   19.5313 |    0.4883 |         - |   119.86 KB |
| EfficientDynamoDb-FromInterface | 100           |     30.28 us |   0.605 us |     0.595 us |    3.8452 |    0.1831 |         - |    23.73 KB |
| aws-sdk-net                     | 100           |  2,446.21 us |  47.644 us |    63.603 us |  476.5625 |  234.3750 |         - |  2956.09 KB |
| EfficientDynamoDb               | 1000          |  2,067.24 us |  27.943 us |    24.770 us |  183.5938 |   89.8438 |         - |  1146.55 KB |
| EfficientDynamoDb-FromInterface | 1000          |    236.34 us |   2.681 us |     2.507 us |   30.2734 |    8.7891 |         - |   185.47 KB |
| aws-sdk-net                     | 1000          | 41,990.48 us | 816.181 us | 1,061.266 us | 4833.3333 | 1250.0000 | 1083.3333 | 29341.08 KB |

```