### PR TITLE
Correctly use ArraySegment in Memory-based converters

### DIFF
--- a/src/EfficientDynamoDb/Internal/Converters/Primitives/Binary/BinaryToMemoryDdbConverter.cs
+++ b/src/EfficientDynamoDb/Internal/Converters/Primitives/Binary/BinaryToMemoryDdbConverter.cs
@@ -13,7 +13,7 @@ namespace EfficientDynamoDb.Internal.Converters.Primitives.Binary
 
         public override AttributeValue Write(ref Memory<byte> value)
         {
-            var array = MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)value, out var segment)
+            var array = MemoryMarshal.TryGetArray((ReadOnlyMemory<byte>)value, out var segment) && segment.Offset == 0 && segment.Count == value.Length
                 ? segment.Array
                 : value.ToArray();
             Debug.Assert(array != null);

--- a/src/EfficientDynamoDb/Internal/Converters/Primitives/Binary/BinaryToReadOnlyMemoryDdbConverter.cs
+++ b/src/EfficientDynamoDb/Internal/Converters/Primitives/Binary/BinaryToReadOnlyMemoryDdbConverter.cs
@@ -13,7 +13,7 @@ namespace EfficientDynamoDb.Internal.Converters.Primitives.Binary
 
         public override AttributeValue Write(ref ReadOnlyMemory<byte> value)
         {
-            var array = MemoryMarshal.TryGetArray(value, out var segment)
+            var array = MemoryMarshal.TryGetArray(value, out var segment) && segment.Offset == 0 && segment.Count == value.Length
                 ? segment.Array
                 : value.ToArray();
             Debug.Assert(array != null);


### PR DESCRIPTION
Fixes the bug with ArraySegment's `Offset` and `Count` usage that was introduced in #242 and pointed out by @bill-poole in #228.