### PR TITLE
Replace `TableNamePrefix` with `ITableNameFormatter` for Better Flexibility

### DIFF
--- a/src/Benchmarks/Benchmarks/SignerBenchmark.cs
+++ b/src/Benchmarks/Benchmarks/SignerBenchmark.cs
@@ -35,7 +35,7 @@ namespace Benchmarks
                 ReturnConsumedCapacity = ReturnConsumedCapacity.Total
             };
 
-            var httpContent = new GetItemHttpContent(request, request.TableName, request.Key.PartitionKeyName!, request.Key.SortKeyName);
+            var httpContent = new GetItemHttpContent(request, null, request.Key.PartitionKeyName!, request.Key.SortKeyName);
             _httpRequest = new HttpRequestMessage(HttpMethod.Post, RegionEndpoint.USEast1.RequestUri)
             {
                 Content = httpContent

--- a/src/EfficientDynamoDb/Configs/ITableNameFormatter.cs
+++ b/src/EfficientDynamoDb/Configs/ITableNameFormatter.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace EfficientDynamoDb.Configs
+{
+	public readonly struct TableNameFormatterContext
+	{
+		public TableNameFormatterContext(string tableName) {
+			TableName = tableName;
+		}
+
+		public string TableName { get; }
+	}
+
+	public interface ITableNameFormatter
+	{
+		int CalculateLength(ref TableNameFormatterContext context);
+		bool TryFormat(Span<char> buffer, ref TableNameFormatterContext context, out int length);
+	}
+}

--- a/src/EfficientDynamoDb/Configs/PrefixTableNameFormatter.cs
+++ b/src/EfficientDynamoDb/Configs/PrefixTableNameFormatter.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace EfficientDynamoDb.Configs
+{
+	public class PrefixTableNameFormatter : ITableNameFormatter
+	{
+		public string Prefix { get; }
+
+		public PrefixTableNameFormatter(string prefix) {
+			Prefix = prefix;
+		}
+
+		public string FormatTableName(ref TableNameFormatterContext context) {
+			return $"{Prefix}{context.TableName}";
+		}
+
+		public int CalculateLength(ref TableNameFormatterContext context) => Prefix.Length + context.TableName.Length;
+
+		public bool TryFormat(Span<char> buffer, ref TableNameFormatterContext context, out int length) {
+			length = Prefix.Length + context.TableName.Length;
+			if( buffer.Length < length ) {
+				return false;
+			}
+			Prefix.AsSpan().CopyTo(buffer);
+			context.TableName.AsSpan().CopyTo(buffer[Prefix.Length..]);
+			return true;
+		}
+	}
+}

--- a/src/EfficientDynamoDb/Configs/TableNameFormatterExtensions.cs
+++ b/src/EfficientDynamoDb/Configs/TableNameFormatterExtensions.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+using EfficientDynamoDb.Exceptions;
+using EfficientDynamoDb.Internal.Core;
+
+namespace EfficientDynamoDb.Configs
+{
+	internal static class TableNameFormatterExtensions
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static void WriteTableName<TState>(this ITableNameFormatter tableNameFormatter, string tableName, TState state, SpanAction<char,TState> writer) {
+			var tableNameContext = new TableNameFormatterContext(tableName);
+			var length = tableNameFormatter.CalculateLength(ref tableNameContext);
+
+			char[]? pooledArray = null;
+			var arr = length < NoAllocStringBuilder.MaxStackAllocSize
+				? stackalloc char[length]
+				: pooledArray = ArrayPool<char>.Shared.Rent(length);
+
+			try
+			{
+				if( !tableNameFormatter.TryFormat(arr, ref tableNameContext, out length) ) {
+					throw new DdbException($"Couldn't format table name '{tableName}' using the provided formatter");
+				}
+
+				writer(arr[..length], state);
+			}
+			finally
+			{
+				if (pooledArray != null)
+				{
+					pooledArray.AsSpan(0, length).Clear();
+					ArrayPool<char>.Shared.Return(pooledArray);
+				}
+			}
+		}
+	}
+}

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext,BatchWriteItem.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbContext,BatchWriteItem.cs
@@ -22,7 +22,7 @@ namespace EfficientDynamoDb
         
         internal async Task BatchWriteItemAsync(BuilderNode node, CancellationToken cancellationToken = default)
         {
-            using var httpContent = new BatchWriteItemHighLevelHttpContent(this, node, Config.TableNamePrefix);
+            using var httpContent = new BatchWriteItemHighLevelHttpContent(this, node, Config.TableNameFormatter);
 
             using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
             var documentResult = await DynamoDbLowLevelContext.ReadDocumentAsync(response, BatchWriteItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
@@ -47,7 +47,7 @@ namespace EfficientDynamoDb
         
         internal async Task<BatchWriteItemResponse> BatchWriteItemResponseAsync(BuilderNode node, CancellationToken cancellationToken = default)
         {
-            using var httpContent = new BatchWriteItemHighLevelHttpContent(this, node, Config.TableNamePrefix);
+            using var httpContent = new BatchWriteItemHighLevelHttpContent(this, node, Config.TableNameFormatter);
 
             using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
             var documentResult = await DynamoDbLowLevelContext.ReadDocumentAsync(response, BatchWriteItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);

--- a/src/EfficientDynamoDb/DynamoDbContext/DynamoDbLowLevelContext.cs
+++ b/src/EfficientDynamoDb/DynamoDbContext/DynamoDbLowLevelContext.cs
@@ -57,7 +57,7 @@ namespace EfficientDynamoDb
         
         public async Task<BatchGetItemResponse> BatchGetItemAsync(BatchGetItemRequest request, CancellationToken cancellationToken = default)
         {
-            using var httpContent = new BatchGetItemHttpContent(request, Config.TableNamePrefix);
+            using var httpContent = new BatchGetItemHttpContent(request, Config.TableNameFormatter);
             
             using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, BatchGetItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
@@ -67,7 +67,7 @@ namespace EfficientDynamoDb
         
         public async Task<BatchWriteItemResponse> BatchWriteItemAsync(BatchWriteItemRequest request, CancellationToken cancellationToken = default)
         {
-            using var httpContent = new BatchWriteItemHttpContent(request, Config.TableNamePrefix);
+            using var httpContent = new BatchWriteItemHttpContent(request, Config.TableNameFormatter);
             
             using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, BatchWriteItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
@@ -77,7 +77,7 @@ namespace EfficientDynamoDb
 
         public async Task<QueryResponse> QueryAsync(QueryRequest request, CancellationToken cancellationToken = default)
         {
-            using var httpContent = new QueryHttpContent(request, Config.TableNamePrefix);
+            using var httpContent = new QueryHttpContent(request, Config.TableNameFormatter);
             
             using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, QueryParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
@@ -87,7 +87,7 @@ namespace EfficientDynamoDb
 
         public async Task<ScanResponse> ScanAsync(ScanRequest request, CancellationToken cancellationToken = default)
         {
-            using var httpContent = new ScanHttpContent(request, Config.TableNamePrefix);
+            using var httpContent = new ScanHttpContent(request, Config.TableNameFormatter);
 
             using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, QueryParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
@@ -97,7 +97,7 @@ namespace EfficientDynamoDb
         
         public async Task<TransactGetItemsResponse> TransactGetItemsAsync(TransactGetItemsRequest request, CancellationToken cancellationToken = default)
         {
-            using var httpContent = new TransactGetItemsHttpContent(request, Config.TableNamePrefix);
+            using var httpContent = new TransactGetItemsHttpContent(request, Config.TableNameFormatter);
 
             using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, TransactGetItemsParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
@@ -107,7 +107,7 @@ namespace EfficientDynamoDb
 
         public async Task<PutItemResponse> PutItemAsync(PutItemRequest request, CancellationToken cancellationToken = default)
         {
-            using var httpContent = new PutItemHttpContent(request, Config.TableNamePrefix);
+            using var httpContent = new PutItemHttpContent(request, Config.TableNameFormatter);
             
             using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, PutItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
@@ -131,7 +131,7 @@ namespace EfficientDynamoDb
                 ? (request.Key.PartitionKeyName!, request.Key.SortKeyName)
                 : await GetKeyNamesAsync(request.TableName).ConfigureAwait(false);
 
-            using var httpContent = new DeleteItemHttpContent(request, pkName, skName, Config.TableNamePrefix);
+            using var httpContent = new DeleteItemHttpContent(request, pkName, skName, Config.TableNameFormatter);
             
             using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, PutItemParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
@@ -141,7 +141,7 @@ namespace EfficientDynamoDb
         
         public async Task<TransactWriteItemsResponse> TransactWriteItemsAsync(TransactWriteItemsRequest request, CancellationToken cancellationToken = default)
         {
-            using var httpContent = new TransactWriteItemsHttpContent(request, Config.TableNamePrefix);
+            using var httpContent = new TransactWriteItemsHttpContent(request, Config.TableNameFormatter);
             
             using var response = await Api.SendAsync(Config, httpContent, cancellationToken).ConfigureAwait(false);
             var result = await ReadDocumentAsync(response, TransactWriteItemsParsingOptions.Instance, cancellationToken).ConfigureAwait(false);
@@ -165,19 +165,19 @@ namespace EfficientDynamoDb
         private async ValueTask<HttpContent> BuildHttpContentAsync(GetItemRequest request)
         {
             if (request.Key!.HasKeyNames)
-                return new GetItemHttpContent(request, Config.TableNamePrefix, request.Key.PartitionKeyName!, request.Key.SortKeyName!);
+                return new GetItemHttpContent(request, Config.TableNameFormatter, request.Key.PartitionKeyName!, request.Key.SortKeyName!);
 
             var (remotePkName, remoteSkName) = await GetKeyNamesAsync(request.TableName);
-            return new GetItemHttpContent(request, Config.TableNamePrefix, remotePkName, remoteSkName!);
+            return new GetItemHttpContent(request, Config.TableNameFormatter, remotePkName, remoteSkName!);
         }
         
         private async ValueTask<HttpContent> BuildHttpContentAsync(UpdateItemRequest request)
         {
             if (request.Key!.HasKeyNames)
-                return new UpdateItemHttpContent(request, Config.TableNamePrefix, request.Key.PartitionKeyName!, request.Key.SortKeyName!);
+                return new UpdateItemHttpContent(request, Config.TableNameFormatter, request.Key.PartitionKeyName!, request.Key.SortKeyName!);
 
             var (remotePkName, remoteSkName) = await GetKeyNamesAsync(request.TableName);
-            return new UpdateItemHttpContent(request, Config.TableNamePrefix, remotePkName, remoteSkName!);
+            return new UpdateItemHttpContent(request, Config.TableNameFormatter, remotePkName, remoteSkName!);
         }
         
         private async ValueTask<(string Pk, string? Sk)> GetKeyNamesAsync(string tableName)
@@ -192,7 +192,7 @@ namespace EfficientDynamoDb
             
             async Task<(string Pk, string? Sk)> CreateKeyNamesTaskAsync(string table)
             {
-                var response = await Api.SendAsync<DescribeTableResponse>(Config, new DescribeTableRequestHttpContent(Config.TableNamePrefix, tableName))
+                var response = await Api.SendAsync<DescribeTableResponse>(Config, new DescribeTableRequestHttpContent(Config.TableNameFormatter, tableName))
                     .ConfigureAwait(false);
 
                 var keySchema = response.Table.KeySchema;

--- a/src/EfficientDynamoDb/DynamoDbContextConfig.cs
+++ b/src/EfficientDynamoDb/DynamoDbContextConfig.cs
@@ -13,7 +13,13 @@ namespace EfficientDynamoDb
         
         internal DynamoDbContextMetadata Metadata { get; private set; }
 
-        public string? TableNamePrefix { get; set; }
+        [Obsolete("Use TableNameFormatter property instead")]
+        public string? TableNamePrefix {
+            get => TableNameFormatter is PrefixTableNameFormatter f ? f.Prefix : null;
+            set => TableNameFormatter = value == null ? null : new PrefixTableNameFormatter(value);
+        }
+
+        public ITableNameFormatter? TableNameFormatter { get; set; }
 
         public RetryStrategies RetryStrategies { get; } = new RetryStrategies();
 

--- a/src/EfficientDynamoDb/DynamoDbManagementContext.cs
+++ b/src/EfficientDynamoDb/DynamoDbManagementContext.cs
@@ -19,7 +19,7 @@ namespace EfficientDynamoDb
 
         public async Task<DescribeTableResponse> DescribeTableAsync(string tableName, CancellationToken cancellationToken = default)
         {
-            var httpContent = new DescribeTableRequestHttpContent(_config.TableNamePrefix, tableName);
+            var httpContent = new DescribeTableRequestHttpContent(_config.TableNameFormatter, tableName);
 
             var response = await _api.SendAsync<DescribeTableResponse>(_config, httpContent, cancellationToken).ConfigureAwait(false);
 

--- a/src/EfficientDynamoDb/Internal/Extensions/Utf8JsonWriterExtensions.UpdateItem.cs
+++ b/src/EfficientDynamoDb/Internal/Extensions/Utf8JsonWriterExtensions.UpdateItem.cs
@@ -51,7 +51,7 @@ namespace EfficientDynamoDb.Internal.Extensions
                         break;
                     }
                     case BuilderNodeType.TableName:
-                        ((TableNameNode) currentNode).WriteTableName(in ddbWriter, ref writeState, config.TableNamePrefix);
+                        ((TableNameNode) currentNode).WriteTableName(in ddbWriter, ref writeState, config.TableNameFormatter);
                         break;
                     default:
                     {

--- a/src/EfficientDynamoDb/Internal/Extensions/Utf8JsonWriterExtensions.cs
+++ b/src/EfficientDynamoDb/Internal/Extensions/Utf8JsonWriterExtensions.cs
@@ -54,29 +54,7 @@ namespace EfficientDynamoDb.Internal.Extensions
                 return;
             }
 
-            var tableNameContext = new TableNameFormatterContext(tableName);
-            var length = tableNameFormatter.CalculateLength(ref tableNameContext);
-
-            char[]? pooledArray = null;
-            var arr = length < NoAllocStringBuilder.MaxStackAllocSize
-                ? stackalloc char[length]
-                : pooledArray = ArrayPool<char>.Shared.Rent(length);
-
-            try
-            {
-                if( !tableNameFormatter.TryFormat(arr, ref tableNameContext, out length) ) {
-                    throw new DdbException($"Couldn't format table name '{tableName}' using the provided formatter");
-                }
-                writer.WriteString(tableNameKey, arr);
-            }
-            finally
-            {
-                if (pooledArray != null)
-                {
-                    pooledArray.AsSpan(0, length).Clear();
-                    ArrayPool<char>.Shared.Return(pooledArray);
-                }
-            }
+            tableNameFormatter.WriteTableName(tableName, writer, (arr, w) => w.WriteString(tableNameKey, arr));
         }
 
         /// <summary>

--- a/src/EfficientDynamoDb/Internal/Operations/BatchGetItem/BatchGetItemHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/BatchGetItem/BatchGetItemHighLevelHttpContent.cs
@@ -101,7 +101,7 @@ namespace EfficientDynamoDb.Internal.Operations.BatchGetItem
                             writer.WriteEndObject();
                         }
 
-                        WriteTableNameAsKey(writer, _context.Config.TableNamePrefix, tableName!);
+                        WriteTableNameAsKey(writer, _context.Config.TableNameFormatter, tableName!);
                         writer.WriteStartObject();
                         
                         writer.WritePropertyName("Keys");
@@ -133,7 +133,7 @@ namespace EfficientDynamoDb.Internal.Operations.BatchGetItem
             
             foreach (var tableBuilder in tablesNode.Value)
             {
-                WriteTableNameAsKey(writer, _context.Config.TableNamePrefix, GetTableName(tableBuilder));
+                WriteTableNameAsKey(writer, _context.Config.TableNameFormatter, GetTableName(tableBuilder));
                 writer.WriteStartObject();
 
                 var hasProjections = false;

--- a/src/EfficientDynamoDb/Internal/Operations/BatchGetItem/BatchGetItemHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/BatchGetItem/BatchGetItemHttpContent.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Operations.Shared;
@@ -10,12 +11,12 @@ namespace EfficientDynamoDb.Internal.Operations.BatchGetItem
     internal sealed class BatchGetItemHttpContent : BatchItemHttpContent
     {
         private readonly BatchGetItemRequest _request;
-        private readonly string? _tableNamePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
 
-        public BatchGetItemHttpContent(BatchGetItemRequest request, string? tableNamePrefix) : base("DynamoDB_20120810.BatchGetItem")
+        public BatchGetItemHttpContent(BatchGetItemRequest request, ITableNameFormatter? tableNameFormatter) : base("DynamoDB_20120810.BatchGetItem")
         {
             _request = request;
-            _tableNamePrefix = tableNamePrefix;
+            _tableNameFormatter = tableNameFormatter;
         }
 
         protected override async ValueTask WriteDataAsync(DdbWriter ddbWriter)
@@ -28,7 +29,7 @@ namespace EfficientDynamoDb.Internal.Operations.BatchGetItem
 
             foreach (var item in _request.RequestItems!)
             {
-                WriteTableNameAsKey(writer, _tableNamePrefix, item.Key);
+                WriteTableNameAsKey(writer, _tableNameFormatter, item.Key);
                 writer.WriteStartObject();
 
                 writer.WritePropertyName("Keys");

--- a/src/EfficientDynamoDb/Internal/Operations/BatchWriteItem/BatchWriteItemHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/BatchWriteItem/BatchWriteItemHighLevelHttpContent.cs
@@ -2,6 +2,7 @@ using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Exceptions;
 using EfficientDynamoDb.Internal.Extensions;
@@ -17,13 +18,13 @@ namespace EfficientDynamoDb.Internal.Operations.BatchWriteItem
         private const int OperationsLimit = 25;
         
         private readonly BuilderNode _node;
-        private readonly string? _tableNamePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
         private readonly DynamoDbContext _context;
 
-        public BatchWriteItemHighLevelHttpContent(DynamoDbContext context, BuilderNode node, string? tableNamePrefix) : base("DynamoDB_20120810.BatchWriteItem")
+        public BatchWriteItemHighLevelHttpContent(DynamoDbContext context, BuilderNode node, ITableNameFormatter? tableNameFormatter) : base("DynamoDB_20120810.BatchWriteItem")
         {
             _node = node;
-            _tableNamePrefix = tableNamePrefix;
+            _tableNameFormatter = tableNameFormatter;
             _context = context;
         }
         
@@ -94,7 +95,7 @@ namespace EfficientDynamoDb.Internal.Operations.BatchWriteItem
                     if (i != 0)
                         writer.WriteEndArray();
 
-                    WriteTableNameAsKey(writer, _tableNamePrefix, tableName!);
+                    WriteTableNameAsKey(writer, _tableNameFormatter, tableName!);
                     writer.WriteStartArray();
 
                     currentTable = tableName;

--- a/src/EfficientDynamoDb/Internal/Operations/BatchWriteItem/BatchWriteItemHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/BatchWriteItem/BatchWriteItemHttpContent.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Operations.Shared;
@@ -10,12 +11,12 @@ namespace EfficientDynamoDb.Internal.Operations.BatchWriteItem
     internal class BatchWriteItemHttpContent : BatchItemHttpContent
     {
         private readonly BatchWriteItemRequest _request;
-        private readonly string? _tableNamePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
 
-        public BatchWriteItemHttpContent(BatchWriteItemRequest request, string? tableNamePrefix) : base("DynamoDB_20120810.BatchWriteItem")
+        public BatchWriteItemHttpContent(BatchWriteItemRequest request, ITableNameFormatter? tableNameFormatter) : base("DynamoDB_20120810.BatchWriteItem")
         {
             _request = request;
-            _tableNamePrefix = tableNamePrefix;
+            _tableNameFormatter = tableNameFormatter;
         }
 
         protected override async ValueTask WriteDataAsync(DdbWriter ddbWriter)
@@ -28,7 +29,7 @@ namespace EfficientDynamoDb.Internal.Operations.BatchWriteItem
             
             foreach (var item in _request.RequestItems!)
             {
-                WriteTableNameAsKey(writer, _tableNamePrefix, item.Key);
+                WriteTableNameAsKey(writer, _tableNameFormatter, item.Key);
                 writer.WriteStartArray();
 
                 for (var i = 0; i < item.Value.Count; i++)

--- a/src/EfficientDynamoDb/Internal/Operations/DeleteItem/DeleteEntityHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/DeleteItem/DeleteEntityHighLevelHttpContent.cs
@@ -22,7 +22,7 @@ namespace EfficientDynamoDb.Internal.Operations.DeleteItem
             writer.WriteStartObject();
 
             var classInfo = _config.Metadata.GetOrAddClassInfo<TEntity>();
-            writer.WriteTableName(_config.TableNamePrefix, classInfo.TableName!);
+            writer.WriteTableName(_config.TableNameFormatter, classInfo.TableName!);
 
             writer.WritePropertyName("Key");
             writer.WriteStartObject();

--- a/src/EfficientDynamoDb/Internal/Operations/DeleteItem/DeleteItemHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/DeleteItem/DeleteItemHighLevelHttpContent.cs
@@ -43,7 +43,7 @@ namespace EfficientDynamoDb.Internal.Operations.DeleteItem
                         writeState = writeState.SetBit(NodeBits.Condition);
                         break;
                     case BuilderNodeType.TableName:
-                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNameFormatter);
                         break;
                     default:
                         node.WriteValue(in ddbWriter, ref writeState);
@@ -52,7 +52,7 @@ namespace EfficientDynamoDb.Internal.Operations.DeleteItem
             }
             
             if(!writeState.IsBitSet(NodeBits.TableName))
-                writer.WriteTableName(_context.Config.TableNamePrefix, _classInfo.TableName!);
+                writer.WriteTableName(_context.Config.TableNameFormatter, _classInfo.TableName!);
             
             writer.WriteEndObject();
             

--- a/src/EfficientDynamoDb/Internal/Operations/DeleteItem/DeleteItemHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/DeleteItem/DeleteItemHttpContent.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Operations.Shared;
@@ -14,14 +15,14 @@ namespace EfficientDynamoDb.Internal.Operations.DeleteItem
         private readonly DeleteItemRequest _request;
         private readonly string _pkName;
         private readonly string? _skName;
-        private readonly string? _tablePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
 
-        public DeleteItemHttpContent(DeleteItemRequest request, string pkName, string? skName, string? tablePrefix) : base("DynamoDB_20120810.DeleteItem")
+        public DeleteItemHttpContent(DeleteItemRequest request, string pkName, string? skName, ITableNameFormatter? tableNameFormatter) : base("DynamoDB_20120810.DeleteItem")
         {
             _request = request;
             _pkName = pkName;
             _skName = skName;
-            _tablePrefix = tablePrefix;
+            _tableNameFormatter = tableNameFormatter;
         }
 
         protected override ValueTask WriteDataAsync(DdbWriter ddbWriter)
@@ -31,7 +32,7 @@ namespace EfficientDynamoDb.Internal.Operations.DeleteItem
             
             WritePrimaryKey(writer);
             
-            writer.WriteTableName(_tablePrefix, _request.TableName);
+            writer.WriteTableName(_tableNameFormatter, _request.TableName);
 
             if (_request.ExpressionAttributeNames?.Count > 0)
                 writer.WriteExpressionAttributeNames(_request.ExpressionAttributeNames);

--- a/src/EfficientDynamoDb/Internal/Operations/DescribeTable/DescribeTableRequestHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/DescribeTable/DescribeTableRequestHttpContent.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Operations.Shared;
@@ -8,11 +9,11 @@ namespace EfficientDynamoDb.Internal.Operations.DescribeTable
     internal class DescribeTableRequestHttpContent : DynamoDbHttpContent
     {
         private readonly string _tableName;
-        private readonly string? _tablePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
 
-        public DescribeTableRequestHttpContent(string? tablePrefix, string tableName) : base("DynamoDB_20120810.DescribeTable")
+        public DescribeTableRequestHttpContent(ITableNameFormatter? tableNameFormatter, string tableName) : base("DynamoDB_20120810.DescribeTable")
         {
-            _tablePrefix = tablePrefix;
+            _tableNameFormatter = tableNameFormatter;
             _tableName = tableName;
         }
 
@@ -20,7 +21,7 @@ namespace EfficientDynamoDb.Internal.Operations.DescribeTable
         {
             var writer = ddbWriter.JsonWriter;
             writer.WriteStartObject();
-            writer.WriteTableName(_tablePrefix, _tableName);
+            writer.WriteTableName(_tableNameFormatter, _tableName);
             writer.WriteEndObject();
 
             return default;

--- a/src/EfficientDynamoDb/Internal/Operations/GetItem/GetItemHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/GetItem/GetItemHighLevelHttpContent.cs
@@ -61,7 +61,7 @@ namespace EfficientDynamoDb.Internal.Operations.GetItem
 
                         break;
                     case BuilderNodeType.TableName:
-                        ((TableNameNode) node).WriteTableName(in writer, ref writeState, _context.Config.TableNamePrefix);
+                        ((TableNameNode) node).WriteTableName(in writer, ref writeState, _context.Config.TableNameFormatter);
                         break;
                     default:
                         node.WriteValue(in writer, ref writeState);
@@ -70,7 +70,7 @@ namespace EfficientDynamoDb.Internal.Operations.GetItem
             }
             
             if(!writeState.IsBitSet(NodeBits.TableName))
-                writer.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, _classInfo.TableName!);
+                writer.JsonWriter.WriteTableName(_context.Config.TableNameFormatter, _classInfo.TableName!);
             
             writer.JsonWriter.WriteEndObject();
 

--- a/src/EfficientDynamoDb/Internal/Operations/GetItem/GetItemHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/GetItem/GetItemHttpContent.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Operations.GetItem;
 
@@ -9,7 +10,7 @@ namespace EfficientDynamoDb.Internal.Operations.GetItem
         private readonly string _pkName;
         private readonly string? _skName;
         
-        public GetItemHttpContent(GetItemRequest request, string? tablePrefix, string pkName, string? skName) : base(request, tablePrefix)
+        public GetItemHttpContent(GetItemRequest request, ITableNameFormatter? tableNameFormatter, string pkName, string? skName) : base(request, tableNameFormatter)
         {
             _pkName = pkName;
             _skName = skName;

--- a/src/EfficientDynamoDb/Internal/Operations/GetItem/GetItemHttpContentBase.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/GetItem/GetItemHttpContentBase.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Operations.Shared;
@@ -10,14 +11,14 @@ namespace EfficientDynamoDb.Internal.Operations.GetItem
 {
     internal abstract class GetItemHttpContentBase<TRequest> : DynamoDbHttpContent where TRequest : GetItemRequestBase
     {
-        private readonly string? _tablePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
         
         protected TRequest Request { get; }
 
-        public GetItemHttpContentBase(TRequest request, string? tablePrefix) : base("DynamoDB_20120810.GetItem")
+        public GetItemHttpContentBase(TRequest request, ITableNameFormatter? tableNameFormatter) : base("DynamoDB_20120810.GetItem")
         {
             Request = request;
-            _tablePrefix = tablePrefix;
+            _tableNameFormatter = tableNameFormatter;
         }
 
         protected override ValueTask WriteDataAsync(DdbWriter ddbWriter)
@@ -27,7 +28,7 @@ namespace EfficientDynamoDb.Internal.Operations.GetItem
             
             WritePrimaryKey(in ddbWriter);
 
-            writer.WriteTableName(_tablePrefix, Request.TableName);
+            writer.WriteTableName(_tableNameFormatter, Request.TableName);
 
             if (Request.ConsistentRead)
                 writer.WriteBoolean("ConsistentRead", true);

--- a/src/EfficientDynamoDb/Internal/Operations/PutItem/PutItemHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/PutItem/PutItemHighLevelHttpContent.cs
@@ -58,7 +58,7 @@ namespace EfficientDynamoDb.Internal.Operations.PutItem
                         break;
                     }
                     case BuilderNodeType.TableName:
-                        ((TableNameNode) currentNode).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                        ((TableNameNode) currentNode).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNameFormatter);
                         break;
                     default:
                     {
@@ -71,7 +71,7 @@ namespace EfficientDynamoDb.Internal.Operations.PutItem
             }
             
             if(!writeState.IsBitSet(NodeBits.TableName) && tableName != null)
-                writer.WriteTableName(_context.Config.TableNamePrefix, tableName);
+                writer.WriteTableName(_context.Config.TableNameFormatter, tableName);
 
             writer.WriteEndObject();
         }

--- a/src/EfficientDynamoDb/Internal/Operations/PutItem/PutItemHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/PutItem/PutItemHttpContent.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Operations.PutItem;
@@ -7,7 +8,7 @@ namespace EfficientDynamoDb.Internal.Operations.PutItem
 {
     internal sealed class PutItemHttpContent : PutItemHttpContentBase<PutItemRequest>
     {
-        public PutItemHttpContent(PutItemRequest request, string? tablePrefix) : base(request, tablePrefix)
+        public PutItemHttpContent(PutItemRequest request, ITableNameFormatter? tableNameFormatter) : base(request, tableNameFormatter)
         {
         }
 

--- a/src/EfficientDynamoDb/Internal/Operations/PutItem/PutItemHttpContentBase.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/PutItem/PutItemHttpContentBase.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Operations.Shared;
@@ -9,14 +10,14 @@ namespace EfficientDynamoDb.Internal.Operations.PutItem
 {
     internal abstract class PutItemHttpContentBase<TRequest> : DynamoDbHttpContent where TRequest: PutItemRequestBase
     {
-        private readonly string? _tablePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
         
         protected TRequest Request { get; }
 
-        protected PutItemHttpContentBase(TRequest request, string? tablePrefix) : base("DynamoDB_20120810.PutItem")
+        protected PutItemHttpContentBase(TRequest request, ITableNameFormatter? tableNameFormatter) : base("DynamoDB_20120810.PutItem")
         {
             Request = request;
-            _tablePrefix = tablePrefix;
+            _tableNameFormatter = tableNameFormatter;
         }
 
         protected abstract ValueTask WriteItemAsync(DdbWriter writer);
@@ -29,7 +30,7 @@ namespace EfficientDynamoDb.Internal.Operations.PutItem
             writer.WritePropertyName("Item");
             await WriteItemAsync(ddbWriter).ConfigureAwait(false);
 
-            writer.WriteTableName(_tablePrefix, Request.TableName);
+            writer.WriteTableName(_tableNameFormatter, Request.TableName);
             
             if (Request.ConditionExpression != null)
                 writer.WriteString("ConditionExpression", Request.ConditionExpression);

--- a/src/EfficientDynamoDb/Internal/Operations/Query/QueryHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/Query/QueryHighLevelHttpContent.cs
@@ -48,7 +48,7 @@ namespace EfficientDynamoDb.Internal.Operations.Query
                         break;
                     }
                     case BuilderNodeType.TableName:
-                        ((TableNameNode)currentNode).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                        ((TableNameNode)currentNode).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNameFormatter);
                         break;
                     default:
                     {
@@ -61,7 +61,7 @@ namespace EfficientDynamoDb.Internal.Operations.Query
             }
 
             if (!writeState.IsBitSet(NodeBits.TableName))
-                writer.WriteTableName(_context.Config.TableNamePrefix,
+                writer.WriteTableName(_context.Config.TableNameFormatter,
                     _tableName ?? throw new DdbException("Table name has to be specified either using the DynamoDbTable attribute or WithTableName extension method."));
 
             writer.WriteEndObject();

--- a/src/EfficientDynamoDb/Internal/Operations/Query/QueryHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/Query/QueryHttpContent.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Operations.Query;
@@ -9,12 +10,12 @@ namespace EfficientDynamoDb.Internal.Operations.Query
     internal class QueryHttpContent : IterableHttpContent
     {
         private readonly QueryRequest _request;
-        private readonly string? _tablePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
 
-        public QueryHttpContent(QueryRequest request, string? tablePrefix) : base("DynamoDB_20120810.Query")
+        public QueryHttpContent(QueryRequest request, ITableNameFormatter? tableNameFormatter) : base("DynamoDB_20120810.Query")
         {
             _request = request;
-            _tablePrefix = tablePrefix;
+            _tableNameFormatter = tableNameFormatter;
         }
 
         protected override ValueTask WriteDataAsync(DdbWriter ddbWriter)
@@ -22,7 +23,7 @@ namespace EfficientDynamoDb.Internal.Operations.Query
             var writer = ddbWriter.JsonWriter;
             writer.WriteStartObject();
 
-            writer.WriteTableName(_tablePrefix, _request.TableName);
+            writer.WriteTableName(_tableNameFormatter, _request.TableName);
             writer.WriteString("KeyConditionExpression", _request.KeyConditionExpression);
             
             if(_request.IndexName != null)

--- a/src/EfficientDynamoDb/Internal/Operations/Scan/ScanHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/Scan/ScanHighLevelHttpContent.cs
@@ -46,7 +46,7 @@ namespace EfficientDynamoDb.Internal.Operations.Scan
                             projectedAttributesStart ??= node;
                             break;
                         case BuilderNodeType.TableName:
-                            ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                            ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNameFormatter);
                             break;
                         default:
                             node.WriteValue(in ddbWriter, ref writeState);
@@ -59,7 +59,7 @@ namespace EfficientDynamoDb.Internal.Operations.Scan
             }
 
             if (!writeState.IsBitSet(NodeBits.TableName))
-                writer.WriteTableName(_context.Config.TableNamePrefix,
+                writer.WriteTableName(_context.Config.TableNameFormatter,
                     _tableName ?? throw new DdbException("Table name has to be specified either using the DynamoDbTable attribute or WithTableName extension method."));
 
             writer.WriteEndObject();

--- a/src/EfficientDynamoDb/Internal/Operations/Scan/ScanHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/Scan/ScanHttpContent.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Operations.Query;
@@ -10,12 +11,12 @@ namespace EfficientDynamoDb.Internal.Operations.Scan
     internal class ScanHttpContent : IterableHttpContent
     {
         private readonly ScanRequest _request;
-        private readonly string? _tablePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
 
-        public ScanHttpContent(ScanRequest request, string? tablePrefix) : base("DynamoDB_20120810.Scan")
+        public ScanHttpContent(ScanRequest request, ITableNameFormatter? tableNameFormatter) : base("DynamoDB_20120810.Scan")
         {
             _request = request;
-            _tablePrefix = tablePrefix;
+            _tableNameFormatter = tableNameFormatter;
         }
 
         protected override ValueTask WriteDataAsync(DdbWriter ddbWriter)
@@ -23,7 +24,7 @@ namespace EfficientDynamoDb.Internal.Operations.Scan
             var writer = ddbWriter.JsonWriter;
             writer.WriteStartObject();
 
-            writer.WriteTableName(_tablePrefix, _request.TableName);
+            writer.WriteTableName(_tableNameFormatter, _request.TableName);
 
             if (_request.IndexName != null)
                 writer.WriteString("IndexName", _request.IndexName);

--- a/src/EfficientDynamoDb/Internal/Operations/Shared/BatchItemHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/Shared/BatchItemHttpContent.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Buffers;
 using System.Text.Json;
+using EfficientDynamoDb.Configs;
+using EfficientDynamoDb.Exceptions;
 using EfficientDynamoDb.Internal.Core;
 
 namespace EfficientDynamoDb.Internal.Operations.Shared
@@ -11,32 +13,37 @@ namespace EfficientDynamoDb.Internal.Operations.Shared
         {
         }
         
-        protected static void WriteTableNameAsKey(Utf8JsonWriter writer, string? prefix, string tableName)
+        protected static void WriteTableNameAsKey(Utf8JsonWriter writer, ITableNameFormatter? tableNameFormatter, string tableName)
         {
-            if (prefix == null)
+            if (tableNameFormatter == null)
             {
                 writer.WritePropertyName(tableName);
                 return;
             }
 
-            var fullLength = prefix.Length + tableName.Length;
+
+
+            var tableNameContext = new TableNameFormatterContext(tableName);
+            var length = tableNameFormatter.CalculateLength(ref tableNameContext);
 
             char[]? pooledArray = null;
-            var arr = fullLength < NoAllocStringBuilder.MaxStackAllocSize
-                ? stackalloc char[fullLength]
-                : pooledArray = ArrayPool<char>.Shared.Rent(fullLength);
+            var arr = length < NoAllocStringBuilder.MaxStackAllocSize
+                ? stackalloc char[length]
+                : pooledArray = ArrayPool<char>.Shared.Rent(length);
 
             try
             {
-                prefix.AsSpan().CopyTo(arr);
-                tableName.AsSpan().CopyTo(arr.Slice(prefix.Length));
-                writer.WritePropertyName(arr);
+                if( !tableNameFormatter.TryFormat(arr, ref tableNameContext, out length) ) {
+                    throw new DdbException($"Couldn't format table name '{tableName}' using the provided formatter");
+                }
+
+                writer.WritePropertyName(arr[..length]);
             }
             finally
             {
                 if (pooledArray != null)
                 {
-                    pooledArray.AsSpan(0, fullLength).Clear();
+                    pooledArray.AsSpan(0, length).Clear();
                     ArrayPool<char>.Shared.Return(pooledArray);
                 }
             }

--- a/src/EfficientDynamoDb/Internal/Operations/Shared/PkAndSkObjectHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/Shared/PkAndSkObjectHttpContent.cs
@@ -24,7 +24,7 @@ namespace EfficientDynamoDb.Internal.Operations.Shared
 
             var classInfo = _context.Config.Metadata.GetOrAddClassInfo<TEntity>();
 
-            writer.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
+            writer.WriteTableName(_context.Config.TableNameFormatter, classInfo.TableName!);
             
             writer.WritePropertyName("Key");
             writer.WriteStartObject();

--- a/src/EfficientDynamoDb/Internal/Operations/Shared/PkObjectHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/Shared/PkObjectHttpContent.cs
@@ -22,7 +22,7 @@ namespace EfficientDynamoDb.Internal.Operations.Shared
 
             var classInfo = _context.Config.Metadata.GetOrAddClassInfo<TEntity>();
             
-            writer.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
+            writer.WriteTableName(_context.Config.TableNameFormatter, classInfo.TableName!);
             
             writer.WritePropertyName("Key");
             writer.WriteStartObject();

--- a/src/EfficientDynamoDb/Internal/Operations/TransactGetItems/TransactGetItemsHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/TransactGetItems/TransactGetItemsHighLevelHttpContent.cs
@@ -101,13 +101,13 @@ namespace EfficientDynamoDb.Internal.Operations.TransactGetItems
                                 projectionWritten = true;
                                 break;
                             case BuilderNodeType.TableName:
-                                ((TableNameNode) getNode).WriteTableName(in ddbWriter, ref getWriteState, _context.Config.TableNamePrefix);
+                                ((TableNameNode) getNode).WriteTableName(in ddbWriter, ref getWriteState, _context.Config.TableNameFormatter);
                                 break;
                         }
                     }
                     
                     if(!getWriteState.IsBitSet(NodeBits.TableName))
-                        writer.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
+                        writer.WriteTableName(_context.Config.TableNameFormatter, classInfo.TableName!);
 
                     writer.WriteEndObject();
 

--- a/src/EfficientDynamoDb/Internal/Operations/TransactGetItems/TransactGetItemsHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/TransactGetItems/TransactGetItemsHttpContent.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Operations.Shared;
@@ -10,12 +11,12 @@ namespace EfficientDynamoDb.Internal.Operations.TransactGetItems
     internal class TransactGetItemsHttpContent : DynamoDbHttpContent
     {
         private readonly TransactGetItemsRequest _request;
-        private readonly string? _tableNamePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
 
-        public TransactGetItemsHttpContent(TransactGetItemsRequest request, string? tableNamePrefix) : base("DynamoDB_20120810.TransactGetItems")
+        public TransactGetItemsHttpContent(TransactGetItemsRequest request, ITableNameFormatter? tableNameFormatter) : base("DynamoDB_20120810.TransactGetItems")
         {
             _request = request;
-            _tableNamePrefix = tableNamePrefix;
+            _tableNameFormatter = tableNameFormatter;
         }
 
         protected override async ValueTask WriteDataAsync(DdbWriter ddbWriter)
@@ -43,7 +44,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactGetItems
                 if (transactItem.ProjectionExpression != null)
                     writer.WriteString("ProjectionExpression", transactItem.ProjectionExpression);
 
-                writer.WriteTableName(_tableNamePrefix, transactItem.TableName);
+                writer.WriteTableName(_tableNameFormatter, transactItem.TableName);
                 writer.WritePrimaryKey(transactItem.Key!);
             
                 writer.WriteEndObject();

--- a/src/EfficientDynamoDb/Internal/Operations/TransactWriteItems/TransactWriteItemsHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/TransactWriteItems/TransactWriteItemsHighLevelHttpContent.cs
@@ -111,7 +111,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
             ddbWriter.WriteUpdateItem(_context.Config, ref builder, visitor, classInfo, item.GetNode(), ref writeState);
 
             if (!writeState.IsBitSet(NodeBits.TableName))
-                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
+                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNameFormatter, classInfo.TableName!);
 
             ddbWriter.JsonWriter.WriteEndObject();
             
@@ -146,7 +146,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
                         writeState = writeState.SetBit(NodeBits.Condition);
                         break;
                     case BuilderNodeType.TableName:
-                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNameFormatter);
                         break;
                     default:
                         node.WriteValue(in ddbWriter, ref writeState);
@@ -155,7 +155,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
             }
             
             if(!writeState.IsBitSet(NodeBits.TableName))
-                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
+                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNameFormatter, classInfo.TableName!);
 
             ddbWriter.JsonWriter.WriteEndObject();
             
@@ -196,7 +196,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
                         writeState = writeState.SetBit(NodeBits.Condition);
                         break;
                     case BuilderNodeType.TableName:
-                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNameFormatter);
                         break;
                     default:
                         node.WriteValue(in ddbWriter, ref writeState);
@@ -207,7 +207,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
             if (!writeState.IsBitSet(NodeBits.TableName))
             {
                 var classInfo = _context.Config.Metadata.GetOrAddClassInfo(item.GetEntityType());
-                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
+                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNameFormatter, classInfo.TableName!);
             }
             
             ddbWriter.JsonWriter.WriteEndObject();
@@ -243,7 +243,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
                         writeState = writeState.SetBit(NodeBits.Condition);
                         break;
                     case BuilderNodeType.TableName:
-                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNamePrefix);
+                        ((TableNameNode) node).WriteTableName(in ddbWriter, ref writeState, _context.Config.TableNameFormatter);
                         break;
                     default:
                         node.WriteValue(in ddbWriter, ref writeState);
@@ -252,7 +252,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
             }
             
             if(!writeState.IsBitSet(NodeBits.TableName))
-                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, classInfo.TableName!);
+                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNameFormatter, classInfo.TableName!);
             
             ddbWriter.JsonWriter.WriteEndObject();
             

--- a/src/EfficientDynamoDb/Internal/Operations/TransactWriteItems/TransactWriteItemsHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/TransactWriteItems/TransactWriteItemsHttpContent.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Operations.Shared;
@@ -12,12 +13,12 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
     internal class TransactWriteItemsHttpContent : DynamoDbHttpContent
     {
         private readonly TransactWriteItemsRequest _request;
-        private readonly string? _tablePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
 
-        public TransactWriteItemsHttpContent(TransactWriteItemsRequest request, string? tablePrefix) : base("DynamoDB_20120810.TransactWriteItems")
+        public TransactWriteItemsHttpContent(TransactWriteItemsRequest request, ITableNameFormatter? tableNameFormatter) : base("DynamoDB_20120810.TransactWriteItems")
         {
             _request = request;
-            _tablePrefix = tablePrefix;
+            _tableNameFormatter = tableNameFormatter;
         }
 
         protected override async ValueTask WriteDataAsync(DdbWriter ddbWriter)
@@ -64,7 +65,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
                     
                     writer.WriteStartObject();
                     
-                    writer.WriteTableName(_tablePrefix, transactItem.Put.TableName);
+                    writer.WriteTableName(_tableNameFormatter, transactItem.Put.TableName);
             
                     if (transactItem.Put.ConditionExpression != null)
                         writer.WriteString("ConditionExpression", transactItem.Put.ConditionExpression);
@@ -135,7 +136,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
             
             writer.WriteStartObject();
             
-            writer.WriteTableName(_tablePrefix, deleteItem.TableName);
+            writer.WriteTableName(_tableNameFormatter, deleteItem.TableName);
             
             if (deleteItem.ConditionExpression != null)
                 writer.WriteString("ConditionExpression", deleteItem.ConditionExpression);
@@ -162,7 +163,7 @@ namespace EfficientDynamoDb.Internal.Operations.TransactWriteItems
                     
             writer.WriteStartObject();
                     
-            writer.WriteTableName(_tablePrefix, updateItem.TableName);
+            writer.WriteTableName(_tableNameFormatter, updateItem.TableName);
             
             if (updateItem.ConditionExpression != null)
                 writer.WriteString("ConditionExpression", updateItem.ConditionExpression);

--- a/src/EfficientDynamoDb/Internal/Operations/UpdateItem/UpdateItemHighLevelHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/UpdateItem/UpdateItemHighLevelHttpContent.cs
@@ -32,7 +32,7 @@ namespace EfficientDynamoDb.Internal.Operations.UpdateItem
             WriteUpdateItem(in ddbWriter, ref writeState);
 
             if (!writeState.IsBitSet(NodeBits.TableName))
-                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNamePrefix, _classInfo.TableName!);
+                ddbWriter.JsonWriter.WriteTableName(_context.Config.TableNameFormatter, _classInfo.TableName!);
 
             ddbWriter.JsonWriter.WriteEndObject();
 

--- a/src/EfficientDynamoDb/Internal/Operations/UpdateItem/UpdateItemHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/UpdateItem/UpdateItemHttpContent.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading.Tasks;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.Internal.Extensions;
 using EfficientDynamoDb.Internal.Operations.Shared;
@@ -14,12 +15,12 @@ namespace EfficientDynamoDb.Internal.Operations.UpdateItem
         private readonly string _pkName;
         private readonly string _skName;
         private readonly UpdateItemRequest _request;
-        private readonly string? _tablePrefix;
+        private readonly ITableNameFormatter? _tableNameFormatter;
 
-        public UpdateItemHttpContent(UpdateItemRequest request, string? tablePrefix, string pkName, string skName) : base("DynamoDB_20120810.UpdateItem")
+        public UpdateItemHttpContent(UpdateItemRequest request, ITableNameFormatter? tableNameFormatter, string pkName, string skName) : base("DynamoDB_20120810.UpdateItem")
         {
             _request = request;
-            _tablePrefix = tablePrefix;
+            _tableNameFormatter = tableNameFormatter;
             _pkName = pkName;
             _skName = skName;
         }
@@ -31,7 +32,7 @@ namespace EfficientDynamoDb.Internal.Operations.UpdateItem
 
             WritePrimaryKey(writer);
 
-            writer.WriteTableName(_tablePrefix, _request.TableName);
+            writer.WriteTableName(_tableNameFormatter, _request.TableName);
             
             if (_request.ConditionExpression != null)
                 writer.WriteString("ConditionExpression", _request.ConditionExpression);

--- a/src/EfficientDynamoDb/Internal/Operations/UpdateItem/UpdateItemSaveHttpContent.cs
+++ b/src/EfficientDynamoDb/Internal/Operations/UpdateItem/UpdateItemSaveHttpContent.cs
@@ -41,7 +41,7 @@ namespace EfficientDynamoDb.Internal.Operations.UpdateItem
         {
             ddbWriter.JsonWriter.WriteStartObject();
 
-            ddbWriter.JsonWriter.WriteTableName(_config.TableNamePrefix, _classInfo.TableName!);
+            ddbWriter.JsonWriter.WriteTableName(_config.TableNameFormatter, _classInfo.TableName!);
 
             ddbWriter.JsonWriter.WritePropertyName("Key");
             ddbWriter.JsonWriter.WriteStartObject();

--- a/src/EfficientDynamoDb/Operations/Query/QueryBuilderNodes.cs
+++ b/src/EfficientDynamoDb/Operations/Query/QueryBuilderNodes.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using EfficientDynamoDb.Configs;
 using EfficientDynamoDb.Converters;
 using EfficientDynamoDb.FluentCondition;
 using EfficientDynamoDb.FluentCondition.Core;
@@ -692,12 +693,12 @@ namespace EfficientDynamoDb.Operations.Query
 
         public override void WriteValue(in DdbWriter writer, ref int state) => throw new NotImplementedException();
 
-        public void WriteTableName(in DdbWriter writer, ref int state, string? prefix)
+        public void WriteTableName(in DdbWriter writer, ref int state, ITableNameFormatter? tableNameFormatter)
         {
             if (state.IsBitSet(NodeBits.TableName))
                 return;
 
-            writer.JsonWriter.WriteTableName(prefix, Value);
+            writer.JsonWriter.WriteTableName(tableNameFormatter, Value);
 
             state = state.SetBit(NodeBits.TableName);
         }


### PR DESCRIPTION
Based on the suggestion from issue https://github.com/AllocZero/EfficientDynamoDb/issues/267

Currently, the API uses a `TableNamePrefix` string to modify table names. This works, but is inflexible.

This PR introduces an `ITableNameFormatter` interface to handle table name resolution.
This allows for:
- Custom naming strategies (e.g., environment-based, hashing, localization)
- Cleaner separation of concerns
- Easier testing and mocking

Migration Path:
- Mark `TableNamePrefix` as `[Obsolete]`
- If `TableNamePrefix` is set, internally create a `PrefixTableNameFormatter` to maintain compatibility

This preserves backward compatibility while enabling greater extensibility.
