### PR TITLE
Fix ArrayDdbConverter ArgumentOutOfRangeException

### DIFF
--- a/src/EfficientDynamoDb/Internal/Converters/Collections/ArrayDdbConverter.cs
+++ b/src/EfficientDynamoDb/Internal/Converters/Collections/ArrayDdbConverter.cs
@@ -55,7 +55,7 @@ namespace EfficientDynamoDb.Internal.Converters.Collections
             var list = new List<AttributeValue>(value.Length);
 
             for (var i = 0; i < value.Length; i++)
-                list[i] = ElementConverter.Write(ref value[i]);
+                list.Add(ElementConverter.Write(ref value[i]));
 
             return new AttributeValue(new ListAttributeValue(list));
         }

--- a/src/EfficientDynamoDb/Internal/Converters/Collections/IReadOnlyCollectionDdbConverter.cs
+++ b/src/EfficientDynamoDb/Internal/Converters/Collections/IReadOnlyCollectionDdbConverter.cs
@@ -54,11 +54,10 @@ namespace EfficientDynamoDb.Internal.Converters.Collections
         {
             var list = new List<AttributeValue>(value.Count);
 
-            var i = 0;
             foreach (var item in value)
             {
                 var itemCopy = item;
-                list[i++] = ElementConverter.Write(ref itemCopy);
+                list.Add(ElementConverter.Write(ref itemCopy));
             }
 
             return new ListAttributeValue(list);


### PR DESCRIPTION
I was trying to do a `.ToDocument` call on an entity with an array property and was getting:
```Unhandled exception. System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')
   at System.Collections.Generic.List`1.set_Item(Int32 index, T value)
   at EfficientDynamoDb.Internal.Converters.Collections.ArrayDdbConverter`1.Write(T[]& value)
   at EfficientDynamoDb.Internal.Metadata.DdbPropertyInfo`1.SetDocumentValue(Object obj, Document document)
   at EfficientDynamoDb.Internal.Extensions.DocumentExtensions.ToDocument[T](T entity, DynamoDbContextMetadata metadata)
   at EfficientDynamoDb.Internal.Converters.ObjectDdbConverter`1.Write(T& value)
   at EfficientDynamoDb.Internal.Metadata.DdbPropertyInfo`1.SetDocumentValue(Object obj, Document document)
   at EfficientDynamoDb.Internal.Extensions.DocumentExtensions.ToDocument[T](T entity, DynamoDbContextMetadata metadata)
   at EfficientDynamoDb.DynamoDbContext.ToDocument[T](T entity)
```

Dug through and found this small bug.

When doing operations directly like `Batch.PutItem` and similar, it seems to write just fine, so probably goes through a different code path.