### PR TITLE
fix: correct typo EUCenteral -> EUCentral

### DIFF
--- a/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
+++ b/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
@@ -132,12 +132,12 @@ namespace EfficientDynamoDb.Configs
         /// <summary>
         /// The Europe (Frankfurt) endpoint.
         /// </summary>
-        public static RegionEndpoint EUCenteral1 => new RegionEndpoint("eu-central-1");
-        
+        public static RegionEndpoint EUCentral1 => new RegionEndpoint("eu-central-1");
+
         /// <summary>
         /// The Europe (Zurich) endpoint.
         /// </summary>
-        public static RegionEndpoint EUCenteral2 => new RegionEndpoint("eu-central-2");
+        public static RegionEndpoint EUCentral2 => new RegionEndpoint("eu-central-2");
         
         /// <summary>
         /// The Europe (Ireland) endpoint.

--- a/website/docs/dev_guide/configuration/region-endpoint.md
+++ b/website/docs/dev_guide/configuration/region-endpoint.md
@@ -63,8 +63,8 @@ var region = RegionEndpoint.Create("local", "http://localhost:8000");
 | ca-central-1    | Canada (Central)           | `RegionEndpoint.CACentral1`   |
 | cn-north-1      | China (Beijing)            | `RegionEndpoint.CNNorth1`     |
 | cn-northwest-1  | China (Ningxia)            | `RegionEndpoint.CNNorthWest1` |
-| eu-central-1    | Europe (Frankfurt)         | `RegionEndpoint.EUCenteral1`  |
-| eu-central-2    | Europe (Zurich)            | `RegionEndpoint.EUCenteral2`  |
+| eu-central-1    | Europe (Frankfurt)         | `RegionEndpoint.EUCentral1`  |
+| eu-central-2    | Europe (Zurich)            | `RegionEndpoint.EUCentral2`  |
 | eu-west-1       | Europe (Ireland)           | `RegionEndpoint.EUWest1`      |
 | eu-west-2       | Europe (London)            | `RegionEndpoint.EUWest2`      |
 | eu-west-3       | Europe (Paris)             | `RegionEndpoint.EUWest3`      |


### PR DESCRIPTION
Fixed: EUCenteral -> EUCentral (4 occurrences in 2 files)

Closes #283