### PR TITLE
fix(config): add EUCentral1/EUCentral2 region endpoint aliases

### DIFF
--- a/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
+++ b/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
@@ -138,6 +138,16 @@ namespace EfficientDynamoDb.Configs
         /// The Europe (Zurich) endpoint.
         /// </summary>
         public static RegionEndpoint EUCenteral2 => new RegionEndpoint("eu-central-2");
+
+        /// <summary>
+        /// The Europe (Frankfurt) endpoint. Spelling alias for <see cref="EUCenteral1"/>.
+        /// </summary>
+        public static RegionEndpoint EUCentral1 => EUCenteral1;
+
+        /// <summary>
+        /// The Europe (Zurich) endpoint. Spelling alias for <see cref="EUCenteral2"/>.
+        /// </summary>
+        public static RegionEndpoint EUCentral2 => EUCenteral2;
         
         /// <summary>
         /// The Europe (Ireland) endpoint.


### PR DESCRIPTION
## Summary
- Add `RegionEndpoint.EUCentral1` and `RegionEndpoint.EUCentral2` as spelling-correct aliases.
- Existing `EUCenteral1` / `EUCenteral2` members are unchanged for backward compatibility.

## Related issue
Fixes #283