### PR TITLE
Region endpoints improvements

### DIFF
--- a/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
+++ b/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
@@ -132,12 +132,24 @@ namespace EfficientDynamoDb.Configs
         /// <summary>
         /// The Europe (Frankfurt) endpoint.
         /// </summary>
-        public static RegionEndpoint EUCenteral1 => new RegionEndpoint("eu-central-1");
+        [Obsolete($"This property will be removed in future release. Use {nameof(EUCentral1)} instead.")]
+        public static RegionEndpoint EUCenteral1 => EUCentral1;
+        
+        /// <summary>
+        /// The Europe (Frankfurt) endpoint.
+        /// </summary>
+        public static RegionEndpoint EUCentral1 => new RegionEndpoint("eu-central-1");
         
         /// <summary>
         /// The Europe (Zurich) endpoint.
         /// </summary>
-        public static RegionEndpoint EUCenteral2 => new RegionEndpoint("eu-central-2");
+        [Obsolete($"This property will be removed in future release. Use {nameof(EUCentral2)} instead.")]
+        public static RegionEndpoint EUCenteral2 => EUCentral2;
+        
+        /// <summary>
+        /// The Europe (Zurich) endpoint.
+        /// </summary>
+        public static RegionEndpoint EUCentral2 => new RegionEndpoint("eu-central-2");
         
         /// <summary>
         /// The Europe (Ireland) endpoint.

--- a/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
+++ b/src/EfficientDynamoDb/Configs/RegionEndpoint.cs
@@ -68,6 +68,11 @@ namespace EfficientDynamoDb.Configs
         /// The Asia Pacific (Hong Kong) endpoint.
         /// </summary>
         public static RegionEndpoint APEast1 => new RegionEndpoint("ap-east-1");
+
+        /// <summary>
+        /// The Asia Pacific (Taipei) endpoint.
+        /// </summary>
+        public static RegionEndpoint APEast2 => new RegionEndpoint("ap-east-2");
         
         /// <summary>
         /// The Asia Pacific (Mumbai) endpoint.
@@ -113,12 +118,32 @@ namespace EfficientDynamoDb.Configs
         /// The Asia Pacific (Melbourne) endpoint.
         /// </summary>
         public static RegionEndpoint APSouthEast4 => new RegionEndpoint("ap-southeast-4");
-        
+
+        /// <summary>
+        /// The Asia Pacific (Malaysia) endpoint.
+        /// </summary>
+        public static RegionEndpoint APSouthEast5 => new RegionEndpoint("ap-southeast-5");
+
+        /// <summary>
+        /// The Asia Pacific (New Zealand) endpoint.
+        /// </summary>
+        public static RegionEndpoint APSouthEast6 => new RegionEndpoint("ap-southeast-6");
+
+        /// <summary>
+        /// The Asia Pacific (Thailand) endpoint.
+        /// </summary>
+        public static RegionEndpoint APSouthEast7 => new RegionEndpoint("ap-southeast-7");
+
         /// <summary>
         /// The Canada (Central) endpoint.
         /// </summary>
         public static RegionEndpoint CACentral1 => new RegionEndpoint("ca-central-1");
-        
+
+        /// <summary>
+        /// The Canada West (Calgary) endpoint.
+        /// </summary>
+        public static RegionEndpoint CAWest1 => new RegionEndpoint("ca-west-1");
+
         /// <summary>
         /// The China (Beijing) endpoint.
         /// </summary>
@@ -200,7 +225,12 @@ namespace EfficientDynamoDb.Configs
         /// The South America (São Paulo) endpoint.
         /// </summary>
         public static RegionEndpoint SAEast1 => new RegionEndpoint("sa-east-1");
-        
+
+        /// <summary>
+        /// The Mexico (Central) endpoint.
+        /// </summary>
+        public static RegionEndpoint MXCentral1 => new RegionEndpoint("mx-central-1");
+
         /// <summary>
         /// The AWS GovCloud (US-East) endpoint.
         /// </summary>

--- a/website/docs/dev_guide/configuration/region-endpoint.md
+++ b/website/docs/dev_guide/configuration/region-endpoint.md
@@ -63,8 +63,8 @@ var region = RegionEndpoint.Create("local", "http://localhost:8000");
 | ca-central-1    | Canada (Central)           | `RegionEndpoint.CACentral1`   |
 | cn-north-1      | China (Beijing)            | `RegionEndpoint.CNNorth1`     |
 | cn-northwest-1  | China (Ningxia)            | `RegionEndpoint.CNNorthWest1` |
-| eu-central-1    | Europe (Frankfurt)         | `RegionEndpoint.EUCenteral1`  |
-| eu-central-2    | Europe (Zurich)            | `RegionEndpoint.EUCenteral2`  |
+| eu-central-1    | Europe (Frankfurt)         | `RegionEndpoint.EUCentral1`   |
+| eu-central-2    | Europe (Zurich)            | `RegionEndpoint.EUCentral2`   |
 | eu-west-1       | Europe (Ireland)           | `RegionEndpoint.EUWest1`      |
 | eu-west-2       | Europe (London)            | `RegionEndpoint.EUWest2`      |
 | eu-west-3       | Europe (Paris)             | `RegionEndpoint.EUWest3`      |

--- a/website/docs/dev_guide/configuration/region-endpoint.md
+++ b/website/docs/dev_guide/configuration/region-endpoint.md
@@ -51,6 +51,7 @@ var region = RegionEndpoint.Create("local", "http://localhost:8000");
 | us-west-2       | US West (Oregon)           | `RegionEndpoint.USWest2`      |
 | af-south-1      | Africa (Cape Town)         | `RegionEndpoint.AFSouth1`     |
 | ap-east-1       | Asia Pacific (Hong Kong)   | `RegionEndpoint.APEast1`      |
+| ap-east-2       | Asia Pacific (Taipei)      | `RegionEndpoint.APEast2`      |
 | ap-south-1      | Asia Pacific (Mumbai)      | `RegionEndpoint.APSouth1`     |
 | ap-south-2      | Asia Pacific (Hyderabad)   | `RegionEndpoint.APSouth2`     |
 | ap-northeast-1  | Asia Pacific (Tokyo)       | `RegionEndpoint.APNorthEast1` |
@@ -60,7 +61,11 @@ var region = RegionEndpoint.Create("local", "http://localhost:8000");
 | ap-southeast-2  | Asia Pacific (Sydney)      | `RegionEndpoint.APSouthEast2` |
 | ap-southeast-3  | Asia Pacific (Jakarta)     | `RegionEndpoint.APSouthEast3` |
 | ap-southeast-4  | Asia Pacific (Melbourne)   | `RegionEndpoint.APSouthEast4` |
+| ap-southeast-5  | Asia Pacific (Malaysia)    | `RegionEndpoint.APSouthEast5` |
+| ap-southeast-6  | Asia Pacific (New Zealand) | `RegionEndpoint.APSouthEast6` |
+| ap-southeast-7  | Asia Pacific (Thailand)    | `RegionEndpoint.APSouthEast7` |
 | ca-central-1    | Canada (Central)           | `RegionEndpoint.CACentral1`   |
+| ca-west-1       | Canada West (Calgary)      | `RegionEndpoint.CAWest1`      |
 | cn-north-1      | China (Beijing)            | `RegionEndpoint.CNNorth1`     |
 | cn-northwest-1  | China (Ningxia)            | `RegionEndpoint.CNNorthWest1` |
 | eu-central-1    | Europe (Frankfurt)         | `RegionEndpoint.EUCentral1`   |
@@ -75,5 +80,6 @@ var region = RegionEndpoint.Create("local", "http://localhost:8000");
 | me-central-1    | Middle East (UAE)          | `RegionEndpoint.MECentral1`   |
 | il-central-1    | Israel (Tel Aviv)          | `RegionEndpoint.ILCentral1`   |
 | sa-east-1       | South America (São Paulo)  | `RegionEndpoint.SAEast1`      |
+| mx-central-1    | Mexico (Central)           | `RegionEndpoint.MXCentral1`   |
 | us-gov-east-1   | AWS GovCloud (US-East)     | `RegionEndpoint.USGovEast1`   |
 | us-gov-west-1   | AWS GovCloud (US)          | `RegionEndpoint.USGovWest1`   |


### PR DESCRIPTION
- Fixes the typo in `EUCentral1` and `EUCentral2` regions reported in #283
- Adds static properties for new DDB regions added since last update.